### PR TITLE
chore: settings allowlist and alpha-loop artifacts

### DIFF
--- a/.alpha-loop/evals/cases/step/implement/captured-057-roblox-dances-app-specific-tests/checks.yaml
+++ b/.alpha-loop/evals/cases/step/implement/captured-057-roblox-dances-app-specific-tests/checks.yaml
@@ -1,0 +1,10 @@
+type: step
+step: implement
+eval_method: pending
+status: needs-annotation
+source: auto-captured
+captured_from:
+  issue: 57
+  session: session/m5-app-batch-2-mid-tier
+  date: 2026-04-09
+checks: []

--- a/.alpha-loop/evals/cases/step/implement/captured-057-roblox-dances-app-specific-tests/issue.md
+++ b/.alpha-loop/evals/cases/step/implement/captured-057-roblox-dances-app-specific-tests/issue.md
@@ -1,0 +1,3 @@
+# Roblox Dances: app-specific tests
+
+Captured from issue #57

--- a/.alpha-loop/evals/cases/step/implement/captured-057-roblox-dances-app-specific-tests/metadata.yaml
+++ b/.alpha-loop/evals/cases/step/implement/captured-057-roblox-dances-app-specific-tests/metadata.yaml
@@ -1,0 +1,8 @@
+id: captured-057-roblox-dances-app-specific-tests
+description: "Roblox Dances: app-specific tests"
+tags: []
+source: auto-captured
+captured_from:
+  issue: 57
+  session: session/m5-app-batch-2-mid-tier
+  date: 2026-04-09

--- a/.alpha-loop/evals/cases/step/implement/captured-058-ai-calculator-component-migration/checks.yaml
+++ b/.alpha-loop/evals/cases/step/implement/captured-058-ai-calculator-component-migration/checks.yaml
@@ -1,0 +1,10 @@
+type: step
+step: implement
+eval_method: pending
+status: needs-annotation
+source: auto-captured
+captured_from:
+  issue: 58
+  session: session/m5-app-batch-2-mid-tier
+  date: 2026-04-09
+checks: []

--- a/.alpha-loop/evals/cases/step/implement/captured-058-ai-calculator-component-migration/issue.md
+++ b/.alpha-loop/evals/cases/step/implement/captured-058-ai-calculator-component-migration/issue.md
@@ -1,0 +1,3 @@
+# AI Calculator: component migration
+
+Captured from issue #58

--- a/.alpha-loop/evals/cases/step/implement/captured-058-ai-calculator-component-migration/metadata.yaml
+++ b/.alpha-loop/evals/cases/step/implement/captured-058-ai-calculator-component-migration/metadata.yaml
@@ -1,0 +1,8 @@
+id: captured-058-ai-calculator-component-migration
+description: "AI Calculator: component migration"
+tags: []
+source: auto-captured
+captured_from:
+  issue: 58
+  session: session/m5-app-batch-2-mid-tier
+  date: 2026-04-09

--- a/.alpha-loop/evals/cases/step/implement/captured-059-ai-calculator-app-specific-tests/checks.yaml
+++ b/.alpha-loop/evals/cases/step/implement/captured-059-ai-calculator-app-specific-tests/checks.yaml
@@ -1,0 +1,10 @@
+type: step
+step: implement
+eval_method: pending
+status: needs-annotation
+source: auto-captured
+captured_from:
+  issue: 59
+  session: session/m5-app-batch-2-mid-tier
+  date: 2026-04-09
+checks: []

--- a/.alpha-loop/evals/cases/step/implement/captured-059-ai-calculator-app-specific-tests/issue.md
+++ b/.alpha-loop/evals/cases/step/implement/captured-059-ai-calculator-app-specific-tests/issue.md
@@ -1,0 +1,3 @@
+# AI Calculator: app-specific tests
+
+Captured from issue #59

--- a/.alpha-loop/evals/cases/step/implement/captured-059-ai-calculator-app-specific-tests/metadata.yaml
+++ b/.alpha-loop/evals/cases/step/implement/captured-059-ai-calculator-app-specific-tests/metadata.yaml
@@ -1,0 +1,8 @@
+id: captured-059-ai-calculator-app-specific-tests
+description: "AI Calculator: app-specific tests"
+tags: []
+source: auto-captured
+captured_from:
+  issue: 59
+  session: session/m5-app-batch-2-mid-tier
+  date: 2026-04-09

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -94,7 +94,10 @@
       "Bash(yes \"\")",
       "Bash(lsof -ti:4747)",
       "Bash(gh api:*)",
-      "Bash(xargs -I {} basename {})"
+      "Bash(xargs -I {} basename {})",
+      "Bash(gh pr:*)",
+      "Bash(npx vercel:*)",
+      "Bash(gh issue:*)"
     ]
   }
 }

--- a/review-issue-36.json
+++ b/review-issue-36.json
@@ -1,0 +1,24 @@
+{
+  "passed": true,
+  "summary": "Sentiment component migration is complete and correct — all shared UI components properly wired, tests updated and passing, no regressions.",
+  "findings": [
+    {
+      "severity": "info",
+      "description": "Changes extend beyond Sentiment app scope: command-center/layout.tsx, meeting-summaries/meetings-app.tsx, uptime/page.tsx, and packages/ui/stat-card.tsx were also modified. These are related fixes (emoji span wrapping, capitalize fix, StatCard SSR/test robustness) but broaden the PR footprint.",
+      "fixed": false,
+      "file": "apps/web/app/apps/command-center/layout.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "Uptime StatusBadge is a local component in uptime/page.tsx, not using @repo/ui StatusBadge. This is intentional (different API shape) but could be a future migration candidate for consistency.",
+      "fixed": false,
+      "file": "apps/web/app/apps/uptime/page.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "Pre-existing TypeScript errors in apps/web/app/apps/uptime/__tests__/page.test.tsx (Function type not assignable) — not introduced by this PR.",
+      "fixed": false,
+      "file": "apps/web/app/apps/uptime/__tests__/page.test.tsx"
+    }
+  ]
+}

--- a/review-issue-38.json
+++ b/review-issue-38.json
@@ -1,0 +1,18 @@
+{
+  "passed": true,
+  "summary": "Component migration to @repo/ui is complete, all 71 tests pass, no TS errors in changed files, exports verified",
+  "findings": [
+    {
+      "severity": "info",
+      "description": "sprint-app.tsx declares `const [error, setError] = useState<string | null>(null)` but neither `error` nor `setError` are ever used — dead code from a removed error-display path",
+      "fixed": false,
+      "file": "apps/web/app/apps/sprint-planning/components/sprint-app.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "Uptime page defines a local `StatusBadge` function while @repo/ui also exports StatusBadge — works fine due to local scope, but could cause confusion during future refactoring",
+      "fixed": false,
+      "file": "apps/web/app/apps/uptime/page.tsx"
+    }
+  ]
+}

--- a/review-issue-39.json
+++ b/review-issue-39.json
@@ -1,0 +1,30 @@
+{
+  "passed": true,
+  "summary": "All 17 sprint-planning tests pass; test coverage is solid across layout, component, and query layers with no critical issues",
+  "findings": [
+    {
+      "severity": "info",
+      "description": "Scope creep: diff includes unrelated changes to command-center, meeting-summaries, sentiment, and uptime components (color token changes, text wrapping) that are not part of sprint-planning tests",
+      "fixed": false,
+      "file": "apps/web/app/apps/sentiment/components/mood-badge.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "Mood-badge and uptime bar colors switched from theme tokens (bg-green, bg-red) to Tailwind defaults (bg-green-500, bg-red-500), creating inconsistency with other components still using theme tokens",
+      "fixed": false,
+      "file": "apps/web/app/apps/uptime/page.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "TabsContent mock always renders children regardless of active tab, so tab switching behavior is not truly tested",
+      "fixed": false,
+      "file": "apps/web/app/apps/sprint-planning/__tests__/sprint-app.test.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "queries.test.ts mock chain is order-dependent on Promise.all call order — reordering queries would silently break tests",
+      "fixed": false,
+      "file": "apps/web/app/apps/sprint-planning/lib/__tests__/queries.test.ts"
+    }
+  ]
+}

--- a/review-issue-40.json
+++ b/review-issue-40.json
@@ -1,0 +1,24 @@
+{
+  "passed": true,
+  "summary": "Dad Joke of the Day component migration is complete and correct — category pills migrated to Badge, empty state to EmptyState, all 294 tests pass",
+  "findings": [
+    {
+      "severity": "info",
+      "description": "Badge renders as <div> with role='button' instead of native <button>. Functionally correct with keyboard handlers, but native <button> is generally preferred for interactive elements. Acceptable given the design intent to use @repo/ui Badge styling.",
+      "fixed": false,
+      "file": "apps/web/app/apps/dad-joke-of-the-day/components/joke-viewer.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "No dedicated test file for joke-viewer.tsx component changes (category pill migration). Existing layout test covers auth gating but not the Badge-based category filter interaction.",
+      "fixed": false,
+      "file": "apps/web/app/apps/dad-joke-of-the-day/components/joke-viewer.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "Three separate imports from @repo/ui on consecutive lines could be consolidated into a single import statement for cleanliness.",
+      "fixed": false,
+      "file": "apps/web/app/apps/dad-joke-of-the-day/components/joke-viewer.tsx"
+    }
+  ]
+}

--- a/review-issue-42.json
+++ b/review-issue-42.json
@@ -1,0 +1,54 @@
+{
+  "passed": false,
+  "summary": "Sentiment mood-badge regression replaces @repo/ui StatusBadge with raw HTML, violating CLAUDE.md non-negotiable; slang-translator XSS fix is good but incomplete for suggestion fallback text",
+  "findings": [
+    {
+      "severity": "critical",
+      "description": "Sentiment mood-badge.tsx replaces StatusBadge (a @repo/ui component) with raw HTML <span> elements and hardcoded styles. This directly violates the CLAUDE.md non-negotiable: 'All shared UI goes through @repo/ui. Do not create app-local copies of components that belong in the shared library.' StatusBadge is active, exported, and working. This change should be reverted — the current code is correct.",
+      "fixed": false,
+      "file": "apps/web/app/apps/sentiment/components/mood-badge.tsx"
+    },
+    {
+      "severity": "warning",
+      "description": "slang-translator escapeHtml is added for user input in translateToGen/translateFromGen (good XSS fix), but the suggestion fallback text still interpolates term names from data without escaping: `Try terms like: ${suggestions}`. While these come from JSON/DB, consistency demands escaping all interpolated content rendered via dangerouslySetInnerHTML.",
+      "fixed": false,
+      "file": "apps/web/app/apps/generations/components/slang-translator.tsx"
+    },
+    {
+      "severity": "warning",
+      "description": "slang-translator layout test (slang-translator/__tests__/layout.test.tsx) expects Topbar component, but the diff was truncated and may not include the actual slang-translator/layout.tsx migration. If the layout file change is missing, tests will fail because the current layout uses a custom <header>, not <Topbar>.",
+      "fixed": false,
+      "file": "apps/web/app/apps/slang-translator/layout.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "Generations layout migration from custom header to Topbar/AppNav is well-done and consistent with the shared component pattern. Good use of navItems array derived from GENERATIONS config.",
+      "fixed": false,
+      "file": "apps/web/app/apps/generations/layout.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "Generation-card migration to Card/CardContent wrapping is clean. Link moved inside CardContent maintains clickability while gaining consistent card styling.",
+      "fixed": false,
+      "file": "apps/web/app/apps/generations/components/generation-card.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "Slang-quiz migration from raw <button> to <Button variant='outline'> with cn() for conditional styling is a clean improvement. Quiz logic and state management are solid.",
+      "fixed": false,
+      "file": "apps/web/app/apps/generations/components/slang-quiz.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "Test coverage is comprehensive: gen-page, generation-card, layout, slang-dictionary, slang-quiz, slang-translator queries/layout/app, and gen-x-map all have meaningful tests with proper mocking patterns.",
+      "fixed": false,
+      "file": "apps/web/app/apps/generations/__tests__/"
+    },
+    {
+      "severity": "info",
+      "description": "Cringe-rizzler changes (Button, Input, Badge migrations) are well-executed but extend beyond the 'Generations' scope in the issue title. Consider whether these belong in a separate PR or are intentionally bundled.",
+      "fixed": false,
+      "file": "apps/web/app/apps/cringe-rizzler/"
+    }
+  ]
+}

--- a/review-issue-47.json
+++ b/review-issue-47.json
@@ -1,0 +1,24 @@
+{
+  "passed": true,
+  "summary": "All 147 tests pass across 6 apps (cringe-rizzler, daily-updates, generations, proper-wine-pour, slang-translator, sentiment). Component migrations to @repo/ui are correct. No critical issues found.",
+  "findings": [
+    {
+      "severity": "info",
+      "description": "Test mock functions use `any` types for component props (standard pattern for @repo/ui mocks across all test files)",
+      "fixed": false,
+      "file": "apps/web/app/apps/cringe-rizzler/__tests__/cringe-app.test.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "Pre-existing TS errors in uptime/__tests__/page.test.tsx and sentiment/__tests__/page.test.tsx (not introduced by this branch)",
+      "fixed": false,
+      "file": "apps/web/app/apps/uptime/__tests__/page.test.tsx"
+    },
+    {
+      "severity": "info",
+      "description": "Cringe-rizzler tests cover structure, tabs, glossary filtering, and actions but skip interactive features (meme download, clipboard copy, category filter). Acceptable for app-specific test scope.",
+      "fixed": false,
+      "file": "apps/web/app/apps/cringe-rizzler/__tests__/cringe-app.test.tsx"
+    }
+  ]
+}

--- a/review-issue-52.json
+++ b/review-issue-52.json
@@ -1,0 +1,5 @@
+{
+  "passed": true,
+  "summary": "HSPT Practice component migration is complete — all native elements replaced with @repo/ui, cn() used for classNames, tests pass (497/497)",
+  "findings": []
+}


### PR DESCRIPTION
## Summary
- Updated `.claude/settings.local.json` with new bash command allowlist entries (`gh pr`, `gh issue`, `npx vercel`)
- Added alpha-loop eval cases for failed M5 issues (#57, #58, #59)
- Added session review JSON artifacts

## Test plan
- [ ] No code changes — config and artifacts only

🤖 Generated with [Claude Code](https://claude.com/claude-code)