### PR TITLE
feat: Wire /api/webhooks/stripe route handler (closes #142)

### DIFF
--- a/apps/web/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe/route.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./route";
+
+const mockHandleStripeWebhook = vi.fn();
+vi.mock("@repo/billing/webhook-handler", () => ({
+  handleStripeWebhook: (...args: unknown[]) => mockHandleStripeWebhook(...args),
+}));
+
+function makeRequest(body: string, headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/webhooks/stripe", {
+    method: "POST",
+    body,
+    headers,
+  });
+}
+
+describe("POST /api/webhooks/stripe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with { received: true } on valid signature", async () => {
+    mockHandleStripeWebhook.mockResolvedValue({ received: true });
+
+    const request = makeRequest("payload", { "stripe-signature": "sig_valid" });
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toEqual({ received: true });
+    expect(mockHandleStripeWebhook).toHaveBeenCalledOnce();
+  });
+
+  it("returns 400 when stripe-signature header is missing", async () => {
+    const request = makeRequest("payload");
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ error: "Missing stripe-signature header" });
+    expect(mockHandleStripeWebhook).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when handleStripeWebhook throws", async () => {
+    mockHandleStripeWebhook.mockRejectedValue(new Error("No signatures found"));
+
+    const request = makeRequest("payload", { "stripe-signature": "sig_bad" });
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ error: "No signatures found" });
+  });
+
+  it("passes raw body as Buffer to handleStripeWebhook", async () => {
+    mockHandleStripeWebhook.mockResolvedValue({ received: true });
+
+    const request = makeRequest("raw-body", { "stripe-signature": "sig_test" });
+    await POST(request);
+
+    const [body, signature] = mockHandleStripeWebhook.mock.calls[0];
+    expect(Buffer.isBuffer(body)).toBe(true);
+    expect(body.toString()).toBe("raw-body");
+    expect(signature).toBe("sig_test");
+  });
+});

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,20 @@
+import { handleStripeWebhook } from "@repo/billing/webhook-handler";
+
+export async function POST(request: Request): Promise<Response> {
+  const signature = request.headers.get("stripe-signature");
+
+  if (!signature) {
+    return Response.json({ error: "Missing stripe-signature header" }, { status: 400 });
+  }
+
+  const arrayBuffer = await request.arrayBuffer();
+  const body = Buffer.from(arrayBuffer);
+
+  try {
+    const result = await handleStripeWebhook(body, signature);
+    return Response.json(result, { status: 200 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return Response.json({ error: message }, { status: 400 });
+  }
+}


### PR DESCRIPTION
Closes #142

## Summary

Automated implementation of **Wire /api/webhooks/stripe route handler**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |
| Details | 857 passed |

## Code Review

All acceptance criteria met — clean webhook route with raw body parsing, signature validation, proper error handling, and 4 passing tests

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*