### PR TITLE
feat: Add subscription management UI (closes #144)

### DIFF
--- a/apps/web/app/(auth)/(dashboard)/account/__tests__/SubscriptionCard.test.tsx
+++ b/apps/web/app/(auth)/(dashboard)/account/__tests__/SubscriptionCard.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen } from "@repo/test-utils";
+import { SubscriptionCard } from "../components/SubscriptionCard";
+import type { Subscription } from "@repo/billing";
+
+vi.mock("../components/ManageSubscriptionButton", () => ({
+  ManageSubscriptionButton: () => (
+    <button type="button">Manage Subscription</button>
+  ),
+}));
+
+const baseSubscription: Subscription = {
+  id: "sub_1",
+  user_id: "user_1",
+  stripe_customer_id: "cus_abc123",
+  stripe_subscription_id: "sub_abc123",
+  tier: "pro",
+  status: "active",
+  current_period_start: "2026-03-15T12:00:00Z",
+  current_period_end: "2026-04-15T12:00:00Z",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("SubscriptionCard", () => {
+  it("shows Free Plan when subscription is null", () => {
+    renderWithProviders(<SubscriptionCard subscription={null} />);
+
+    expect(screen.getByText("Free Plan")).toBeTruthy();
+    expect(screen.getByText("View Pricing")).toBeTruthy();
+    expect(
+      screen.queryByText("Manage Subscription"),
+    ).toBeNull();
+  });
+
+  it("shows Free Plan when subscription has no stripe_customer_id", () => {
+    const sub: Subscription = {
+      ...baseSubscription,
+      stripe_customer_id: null,
+    };
+    renderWithProviders(<SubscriptionCard subscription={sub} />);
+
+    expect(screen.getByText("Free Plan")).toBeTruthy();
+    expect(screen.getByText("View Pricing")).toBeTruthy();
+  });
+
+  it("shows active subscription with tier and status badge", () => {
+    renderWithProviders(<SubscriptionCard subscription={baseSubscription} />);
+
+    expect(screen.getByText("Pro Plan")).toBeTruthy();
+    expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manage Subscription")).toBeTruthy();
+  });
+
+  it("shows renewal date for active subscription", () => {
+    renderWithProviders(<SubscriptionCard subscription={baseSubscription} />);
+
+    expect(screen.getByText("Renewal date")).toBeTruthy();
+    // Date formatted as "April 15, 2026" — mid-month date avoids timezone edge cases
+    expect(screen.getByText(/April 15, 2026/)).toBeTruthy();
+  });
+
+  it("shows Past Due badge and warning for past_due status", () => {
+    const sub: Subscription = { ...baseSubscription, status: "past_due" };
+    renderWithProviders(<SubscriptionCard subscription={sub} />);
+
+    expect(screen.getByText("Past Due")).toBeTruthy();
+    expect(
+      screen.getByText(/update your payment method/i),
+    ).toBeTruthy();
+  });
+
+  it("shows Canceled badge and warning for canceled status", () => {
+    const sub: Subscription = { ...baseSubscription, status: "canceled" };
+    renderWithProviders(<SubscriptionCard subscription={sub} />);
+
+    expect(screen.getAllByText("Canceled").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/access continues until the end of the billing period/i),
+    ).toBeTruthy();
+  });
+
+  it("shows enterprise tier correctly", () => {
+    const sub: Subscription = { ...baseSubscription, tier: "enterprise" };
+    renderWithProviders(<SubscriptionCard subscription={sub} />);
+
+    expect(screen.getByText("Enterprise Plan")).toBeTruthy();
+  });
+
+  it("View Pricing link points to /pricing", () => {
+    renderWithProviders(<SubscriptionCard subscription={null} />);
+
+    const link = screen.getByText("View Pricing").closest("a");
+    expect(link?.getAttribute("href")).toBe("/pricing");
+  });
+});

--- a/apps/web/app/(auth)/(dashboard)/account/__tests__/actions.test.ts
+++ b/apps/web/app/(auth)/(dashboard)/account/__tests__/actions.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock next/headers ─────────────────────────────────────────────────────────
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+// ── Mock @repo/auth/auth0-factory ─────────────────────────────────────────────
+const mockGetSession = vi.fn();
+vi.mock("@repo/auth/auth0-factory", () => ({
+  getHostFromRequestHeaders: vi.fn().mockReturnValue("localhost:3000"),
+  getAuth0ClientForHost: vi.fn().mockReturnValue({
+    getSession: mockGetSession,
+  }),
+}));
+
+// ── Mock @repo/billing ────────────────────────────────────────────────────────
+const mockGetSubscription = vi.fn();
+const mockCreatePortalSession = vi.fn();
+vi.mock("@repo/billing", () => ({
+  getSubscription: mockGetSubscription,
+  createPortalSession: mockCreatePortalSession,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.APP_BASE_URL = "http://localhost:3000";
+});
+
+describe("createPortalSessionAction", () => {
+  it("throws Unauthorized when no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const { createPortalSessionAction } = await import("../actions");
+
+    await expect(createPortalSessionAction()).rejects.toThrow("Unauthorized");
+  });
+
+  it("throws when user has no subscription", async () => {
+    mockGetSession.mockResolvedValue({ user: { sub: "user_1" } });
+    mockGetSubscription.mockResolvedValue(null);
+    const { createPortalSessionAction } = await import("../actions");
+
+    await expect(createPortalSessionAction()).rejects.toThrow(
+      "No active subscription",
+    );
+  });
+
+  it("throws when subscription has no stripe_customer_id", async () => {
+    mockGetSession.mockResolvedValue({ user: { sub: "user_1" } });
+    mockGetSubscription.mockResolvedValue({
+      stripe_customer_id: null,
+      tier: "free",
+      status: "active",
+    });
+    const { createPortalSessionAction } = await import("../actions");
+
+    await expect(createPortalSessionAction()).rejects.toThrow(
+      "No active subscription",
+    );
+  });
+
+  it("returns portal URL when subscription has a customer ID", async () => {
+    mockGetSession.mockResolvedValue({ user: { sub: "user_1" } });
+    mockGetSubscription.mockResolvedValue({
+      stripe_customer_id: "cus_abc123",
+      tier: "pro",
+      status: "active",
+    });
+    mockCreatePortalSession.mockResolvedValue(
+      "https://billing.stripe.com/session/test",
+    );
+    const { createPortalSessionAction } = await import("../actions");
+
+    const url = await createPortalSessionAction();
+
+    expect(url).toBe("https://billing.stripe.com/session/test");
+    expect(mockCreatePortalSession).toHaveBeenCalledWith(
+      "cus_abc123",
+      "http://localhost:3000/account",
+    );
+  });
+
+  it("uses APP_BASE_URL for the return URL", async () => {
+    process.env.APP_BASE_URL = "https://app.example.com";
+    mockGetSession.mockResolvedValue({ user: { sub: "user_1" } });
+    mockGetSubscription.mockResolvedValue({
+      stripe_customer_id: "cus_abc123",
+      tier: "pro",
+      status: "active",
+    });
+    mockCreatePortalSession.mockResolvedValue("https://billing.stripe.com/s/x");
+    const { createPortalSessionAction } = await import("../actions");
+
+    await createPortalSessionAction();
+
+    expect(mockCreatePortalSession).toHaveBeenCalledWith(
+      "cus_abc123",
+      "https://app.example.com/account",
+    );
+  });
+});

--- a/apps/web/app/(auth)/(dashboard)/account/actions.ts
+++ b/apps/web/app/(auth)/(dashboard)/account/actions.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { headers } from "next/headers";
+import {
+  getAuth0ClientForHost,
+  getHostFromRequestHeaders,
+} from "@repo/auth/auth0-factory";
+import { getSubscription, createPortalSession } from "@repo/billing";
+
+export async function createPortalSessionAction(): Promise<string> {
+  const h = await headers();
+  const host = getHostFromRequestHeaders(h);
+  const auth0 = getAuth0ClientForHost(host);
+  const session = await auth0.getSession();
+
+  if (!session?.user?.sub) {
+    throw new Error("Unauthorized");
+  }
+
+  const userId = session.user.sub as string;
+  const subscription = await getSubscription(userId);
+
+  if (!subscription?.stripe_customer_id) {
+    throw new Error("No active subscription");
+  }
+
+  const appUrl = process.env.APP_BASE_URL ?? "http://localhost:3000";
+  const returnUrl = `${appUrl}/account`;
+
+  return createPortalSession(subscription.stripe_customer_id, returnUrl);
+}

--- a/apps/web/app/(auth)/(dashboard)/account/components/ManageSubscriptionButton.tsx
+++ b/apps/web/app/(auth)/(dashboard)/account/components/ManageSubscriptionButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@repo/ui";
+import { createPortalSessionAction } from "../actions";
+
+export function ManageSubscriptionButton() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleClick() {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = await createPortalSessionAction();
+      window.location.href = url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button onClick={handleClick} disabled={loading} variant="outline">
+        {loading ? "Redirecting…" : "Manage Subscription"}
+      </Button>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/app/(auth)/(dashboard)/account/components/SubscriptionCard.tsx
+++ b/apps/web/app/(auth)/(dashboard)/account/components/SubscriptionCard.tsx
@@ -1,0 +1,96 @@
+import { Card, CardContent, CardHeader, CardTitle, StatusBadge } from "@repo/ui";
+import type { Subscription } from "@repo/billing";
+import { ManageSubscriptionButton } from "./ManageSubscriptionButton";
+
+interface SubscriptionCardProps {
+  subscription: Subscription | null;
+}
+
+function formatDate(isoString: string | null): string {
+  if (!isoString) return "—";
+  return new Date(isoString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+export function SubscriptionCard({ subscription }: SubscriptionCardProps) {
+  const isActive =
+    subscription?.status === "active" || subscription?.status === "trialing";
+  const isPastDue = subscription?.status === "past_due";
+  const isCanceled = subscription?.status === "canceled";
+  const hasStripeCustomer = Boolean(subscription?.stripe_customer_id);
+
+  if (!subscription || !hasStripeCustomer) {
+    return (
+      <Card className="glass-sm max-w-lg">
+        <CardHeader>
+          <CardTitle className="text-base">Free Plan</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            You are on the free tier. Upgrade to unlock more features.
+          </p>
+          <a
+            href="/pricing"
+            className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:bg-accent/90 transition-colors"
+          >
+            View Pricing
+          </a>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="glass-sm max-w-lg">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base">
+            {capitalize(subscription.tier)} Plan
+          </CardTitle>
+          {isActive && (
+            <StatusBadge variant="success">Active</StatusBadge>
+          )}
+          {isPastDue && (
+            <StatusBadge variant="warning">Past Due</StatusBadge>
+          )}
+          {isCanceled && (
+            <StatusBadge variant="error">Canceled</StatusBadge>
+          )}
+          {subscription.status === "incomplete" && (
+            <StatusBadge variant="pending">Incomplete</StatusBadge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <dl className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <dt className="text-muted-foreground">Status</dt>
+            <dd className="font-medium">{capitalize(subscription.status.replace("_", " "))}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt className="text-muted-foreground">Renewal date</dt>
+            <dd className="font-medium">{formatDate(subscription.current_period_end)}</dd>
+          </div>
+        </dl>
+        {isPastDue && (
+          <p className="text-sm text-amber-400">
+            Your payment is past due. Please update your payment method to avoid service interruption.
+          </p>
+        )}
+        {isCanceled && (
+          <p className="text-sm text-red-400">
+            Your subscription has been canceled. Access continues until the end of the billing period.
+          </p>
+        )}
+        <ManageSubscriptionButton />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/(auth)/(dashboard)/account/page.tsx
+++ b/apps/web/app/(auth)/(dashboard)/account/page.tsx
@@ -1,0 +1,42 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import {
+  getAuth0ClientForHost,
+  getHostFromRequestHeaders,
+} from "@repo/auth/auth0-factory";
+import { getSubscription } from "@repo/billing";
+import { SubscriptionCard } from "./components/SubscriptionCard";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Account — LR Apps",
+  description: "Manage your subscription and billing.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function AccountPage() {
+  const h = await headers();
+  const host = getHostFromRequestHeaders(h);
+  const auth0 = getAuth0ClientForHost(host);
+  const session = await auth0.getSession();
+
+  if (!session?.user) {
+    redirect("/auth/login");
+  }
+
+  const userId = session.user.sub as string;
+  const subscription = await getSubscription(userId);
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="font-heading text-3xl text-accent mb-1">Subscription</h1>
+        <p className="text-muted-foreground">
+          Manage your plan and billing details.
+        </p>
+      </div>
+      <SubscriptionCard subscription={subscription} />
+    </div>
+  );
+}

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -3,6 +3,7 @@ export { getOrCreateCustomer } from "./customers";
 export { upsertSubscription, getSubscription } from "./subscriptions";
 export { hasFeatureAccess } from "./has-feature-access";
 export { handleStripeWebhook } from "./webhook-handler";
+export { createPortalSession } from "./portal";
 export type {
   Tier,
   Subscription,

--- a/packages/billing/src/portal.test.ts
+++ b/packages/billing/src/portal.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPortalSessionsCreate = vi.hoisted(() => vi.fn());
+
+vi.mock("./stripe-client", () => ({
+  getStripe: vi.fn().mockReturnValue({
+    billingPortal: {
+      sessions: {
+        create: mockPortalSessionsCreate,
+      },
+    },
+  }),
+}));
+
+import { createPortalSession } from "./portal";
+
+describe("createPortalSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls stripe billingPortal.sessions.create with correct params", async () => {
+    mockPortalSessionsCreate.mockResolvedValue({
+      url: "https://billing.stripe.com/session/test_abc",
+    });
+
+    await createPortalSession("cus_test123", "https://app.example.com/account");
+
+    expect(mockPortalSessionsCreate).toHaveBeenCalledWith({
+      customer: "cus_test123",
+      return_url: "https://app.example.com/account",
+    });
+  });
+
+  it("returns the session URL", async () => {
+    const expectedUrl = "https://billing.stripe.com/session/test_abc";
+    mockPortalSessionsCreate.mockResolvedValue({ url: expectedUrl });
+
+    const result = await createPortalSession(
+      "cus_test123",
+      "https://app.example.com/account",
+    );
+
+    expect(result).toBe(expectedUrl);
+  });
+
+  it("propagates Stripe errors", async () => {
+    mockPortalSessionsCreate.mockRejectedValue(
+      new Error("No such customer: cus_invalid"),
+    );
+
+    await expect(
+      createPortalSession("cus_invalid", "https://app.example.com/account"),
+    ).rejects.toThrow("No such customer: cus_invalid");
+  });
+});

--- a/packages/billing/src/portal.ts
+++ b/packages/billing/src/portal.ts
@@ -1,0 +1,13 @@
+import { getStripe } from "./stripe-client";
+
+export async function createPortalSession(
+  stripeCustomerId: string,
+  returnUrl: string,
+): Promise<string> {
+  const stripe = getStripe();
+  const session = await stripe.billingPortal.sessions.create({
+    customer: stripeCustomerId,
+    return_url: returnUrl,
+  });
+  return session.url;
+}


### PR DESCRIPTION
Closes #144

## Summary

Automated implementation of **Add subscription management UI**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | FAIL |
| Details | 879 passed |

## Code Review

Subscription management UI is well-implemented with solid test coverage; payment method display is deferred to Stripe Portal rather than shown inline

- **WARNING** [OPEN] `apps/web/app/(auth)/(dashboard)/account/components/SubscriptionCard.tsx`: AC says 'Shows current tier, renewal date, payment method' but payment method is not displayed on the account page. The Stripe Customer Portal (via Manage Subscription button) covers this, but the literal AC is not met. Adding inline payment method display would require a live Stripe API call (stripe.customers.retrieve with payment method expansion) since the Subscription DB record doesn't store it.
- **INFO** [OPEN] `pricing-error.png`: pricing-error.png (52KB debug screenshot) exists in the repo root but is untracked — not a git issue, just a local artifact that should be cleaned up or added to .gitignore.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*