### PR TITLE
feat: Add webhook idempotency and Stripe test seed (closes #146)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,18 @@ Two small updates applied:
 2. **`lib/` directory listing** — added `app-host.ts`, `proxy-utils.ts`, and `require-app-layout-access.ts` which exist in the codebase but were missing from the docs
 
 Everything else checked out accurately against the current codebase.
+
+## Stripe Test Seed
+
+Populates Stripe test mode with Free, Pro, and Enterprise products and monthly prices.
+
+```bash
+npx tsx scripts/seed-stripe.ts
+```
+
+**Required env var:** `STRIPE_SECRET_KEY` must be a test key (starts with `sk_test_`). The script will refuse to run against live keys.
+
+**What it creates:**
+- Three products: Free ($0/mo), Pro ($19/mo), Enterprise ($99/mo)
+- One monthly recurring price per product
+- Logs the resulting `price_id` for each — copy these into `.env` as `STRIPE_PRICE_ID_FREE`, `STRIPE_PRICE_ID_PRO`, `STRIPE_PRICE_ID_ENTERPRISE`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,6 @@ npx tsx scripts/seed-stripe.ts
 **Required env var:** `STRIPE_SECRET_KEY` must be a test key (starts with `sk_test_`). The script will refuse to run against live keys.
 
 **What it creates:**
-- Three products: Free ($0/mo), Pro ($19/mo), Enterprise ($99/mo)
+- Three products: Free ($0/mo), Pro ($29/mo), Enterprise ($99/mo)
 - One monthly recurring price per product
-- Logs the resulting `price_id` for each — copy these into `.env` as `STRIPE_PRICE_ID_FREE`, `STRIPE_PRICE_ID_PRO`, `STRIPE_PRICE_ID_ENTERPRISE`.
+- Logs the resulting `price_id` for each — copy these into `.env` as `STRIPE_PRICE_ID_PRO`, `STRIPE_PRICE_ID_ENTERPRISE`.

--- a/packages/billing/src/webhook-handler.test.ts
+++ b/packages/billing/src/webhook-handler.test.ts
@@ -14,8 +14,25 @@ vi.mock("./subscriptions", () => ({
     mockUpsertSubscription(...args),
 }));
 
+// Mock DB: tracks inserted event IDs and supports maybeSingle lookup
+let processedEventIds: Set<string> = new Set();
+let insertShouldFail = false;
+
+const mockMaybeSingle = vi.fn();
+const mockEq = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
+const mockSelect = vi.fn(() => ({ eq: mockEq }));
+const mockInsert = vi.fn();
 const mockUpdate = vi.fn(() => ({ eq: vi.fn() }));
-const mockFrom = vi.fn(() => ({ update: mockUpdate }));
+const mockFrom = vi.fn((table: string) => {
+  if (table === "processed_webhook_events") {
+    return {
+      select: mockSelect,
+      insert: mockInsert,
+    };
+  }
+  return { update: mockUpdate };
+});
+
 vi.mock("@repo/db/service-role", () => ({
   createServiceRoleClient: () => ({ from: mockFrom }),
 }));
@@ -25,12 +42,20 @@ import { handleStripeWebhook } from "./webhook-handler";
 describe("handleStripeWebhook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    processedEventIds = new Set();
+    insertShouldFail = false;
     vi.stubEnv("STRIPE_WEBHOOK_SECRET", "whsec_test");
+
+    // Default: event not yet processed
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    // Default: insert succeeds
+    mockInsert.mockResolvedValue({ error: null });
   });
 
   it("calls upsertSubscription on customer.subscription.created", async () => {
     const subscription = { id: "sub_123", customer: "cus_456" };
     mockConstructEvent.mockReturnValue({
+      id: "evt_001",
       type: "customer.subscription.created",
       data: { object: subscription },
     });
@@ -44,6 +69,7 @@ describe("handleStripeWebhook", () => {
   it("calls upsertSubscription on customer.subscription.updated", async () => {
     const subscription = { id: "sub_123", customer: "cus_456" };
     mockConstructEvent.mockReturnValue({
+      id: "evt_002",
       type: "customer.subscription.updated",
       data: { object: subscription },
     });
@@ -56,6 +82,7 @@ describe("handleStripeWebhook", () => {
   it("updates status to canceled on customer.subscription.deleted", async () => {
     const subscription = { id: "sub_123", customer: "cus_456" };
     mockConstructEvent.mockReturnValue({
+      id: "evt_003",
       type: "customer.subscription.deleted",
       data: { object: subscription },
     });
@@ -71,6 +98,7 @@ describe("handleStripeWebhook", () => {
 
   it("returns received: true for unhandled event types", async () => {
     mockConstructEvent.mockReturnValue({
+      id: "evt_004",
       type: "charge.succeeded",
       data: { object: {} },
     });
@@ -87,5 +115,56 @@ describe("handleStripeWebhook", () => {
     await expect(handleStripeWebhook("body", "sig")).rejects.toThrow(
       "STRIPE_WEBHOOK_SECRET",
     );
+  });
+
+  it("returns early without calling upsertSubscription for a duplicate event ID", async () => {
+    const subscription = { id: "sub_dup", customer: "cus_456" };
+    mockConstructEvent.mockReturnValue({
+      id: "evt_duplicate",
+      type: "customer.subscription.created",
+      data: { object: subscription },
+    });
+
+    // Simulate event already processed
+    mockMaybeSingle.mockResolvedValue({
+      data: { event_id: "evt_duplicate" },
+      error: null,
+    });
+
+    const result = await handleStripeWebhook("body", "sig");
+
+    expect(result).toEqual({ received: true });
+    expect(mockUpsertSubscription).not.toHaveBeenCalled();
+  });
+
+  it("inserts event ID into processed_webhook_events after processing", async () => {
+    const subscription = { id: "sub_new", customer: "cus_456" };
+    mockConstructEvent.mockReturnValue({
+      id: "evt_new",
+      type: "customer.subscription.created",
+      data: { object: subscription },
+    });
+
+    await handleStripeWebhook("body", "sig");
+
+    expect(mockInsert).toHaveBeenCalledWith({ event_id: "evt_new" });
+  });
+
+  it("does not throw when insert into processed_webhook_events fails (fail open)", async () => {
+    const subscription = { id: "sub_failopen", customer: "cus_456" };
+    mockConstructEvent.mockReturnValue({
+      id: "evt_failopen",
+      type: "customer.subscription.created",
+      data: { object: subscription },
+    });
+
+    mockInsert.mockRejectedValue(new Error("DB write failed"));
+
+    // Should not throw — fail open
+    const result = await handleStripeWebhook("body", "sig");
+
+    expect(result).toEqual({ received: true });
+    // Event was still processed despite the insert failure
+    expect(mockUpsertSubscription).toHaveBeenCalledWith(subscription);
   });
 });

--- a/packages/billing/src/webhook-handler.ts
+++ b/packages/billing/src/webhook-handler.ts
@@ -26,16 +26,37 @@ export async function handleStripeWebhook(
     return { received: true };
   }
 
+  const db = createServiceRoleClient();
+
+  // Idempotency: skip if this event has already been processed
+  const { data: existing } = await db
+    .from("processed_webhook_events")
+    .select("event_id")
+    .eq("event_id", event.id)
+    .maybeSingle();
+
+  if (existing) {
+    return { received: true };
+  }
+
   const subscription = event.data.object as Stripe.Subscription;
 
   if (event.type === "customer.subscription.deleted") {
-    const db = createServiceRoleClient();
     await db
       .from("subscriptions")
       .update({ status: "canceled", updated_at: new Date().toISOString() })
       .eq("stripe_subscription_id", subscription.id);
   } else {
     await upsertSubscription(subscription);
+  }
+
+  // Record the event ID to prevent duplicate processing
+  try {
+    await db
+      .from("processed_webhook_events")
+      .insert({ event_id: event.id });
+  } catch (err) {
+    console.error("Failed to record processed webhook event:", err);
   }
 
   return { received: true };

--- a/scripts/seed-stripe.ts
+++ b/scripts/seed-stripe.ts
@@ -1,0 +1,66 @@
+/**
+ * Stripe Test Seed Script
+ *
+ * Creates test-mode products and prices in Stripe for local development.
+ * Each product gets a monthly recurring price.
+ *
+ * Usage: npx tsx scripts/seed-stripe.ts
+ *
+ * Requirements:
+ *   - STRIPE_SECRET_KEY must be set and must start with sk_test_
+ */
+
+import Stripe from "stripe";
+
+const key = process.env.STRIPE_SECRET_KEY ?? "";
+
+if (!key) {
+  console.error("Error: STRIPE_SECRET_KEY environment variable is required.");
+  process.exit(1);
+}
+
+if (!key.startsWith("sk_test_")) {
+  console.error(
+    "Error: STRIPE_SECRET_KEY must be a test key (starts with sk_test_). " +
+      "Refusing to run against live keys.",
+  );
+  process.exit(1);
+}
+
+const stripe = new Stripe(key);
+
+const TIERS = [
+  { name: "Free", amount: 0 },
+  { name: "Pro", amount: 1900 },
+  { name: "Enterprise", amount: 9900 },
+] as const;
+
+async function seed() {
+  console.log("Seeding Stripe test products and prices...\n");
+
+  for (const tier of TIERS) {
+    const product = await stripe.products.create({
+      name: tier.name,
+      metadata: { tier: tier.name.toLowerCase() },
+    });
+
+    const price = await stripe.prices.create({
+      product: product.id,
+      unit_amount: tier.amount,
+      currency: "usd",
+      recurring: { interval: "month" },
+      metadata: { tier: tier.name.toLowerCase() },
+    });
+
+    console.log(`${tier.name}:`);
+    console.log(`  product_id: ${product.id}`);
+    console.log(`  price_id:   ${price.id}`);
+  }
+
+  console.log("\nDone. Add price IDs to your .env as STRIPE_PRICE_ID_<TIER>.");
+}
+
+seed().catch((err) => {
+  console.error("Seed failed:", err);
+  process.exit(1);
+});

--- a/scripts/seed-stripe.ts
+++ b/scripts/seed-stripe.ts
@@ -31,7 +31,7 @@ const stripe = new Stripe(key);
 
 const TIERS = [
   { name: "Free", amount: 0 },
-  { name: "Pro", amount: 1900 },
+  { name: "Pro", amount: 2900 },
   { name: "Enterprise", amount: 9900 },
 ] as const;
 

--- a/supabase/migrations/003_webhook_events.sql
+++ b/supabase/migrations/003_webhook_events.sql
@@ -1,0 +1,7 @@
+-- Create table to track processed Stripe webhook events for idempotency
+create table if not exists public.processed_webhook_events (
+  event_id text primary key,
+  processed_at timestamptz default now() not null
+);
+
+-- No RLS — only accessible via service role key (server-side only)


### PR DESCRIPTION
Closes #146

## Summary

Automated implementation of **Add webhook idempotency and Stripe test seed**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |
| Details | 889 passed |

## Code Review

Webhook idempotency and Stripe seed script implemented correctly; fixed pricing mismatch and doc inaccuracy

- **WARNING** [FIXED] `scripts/seed-stripe.ts`: Seed script Pro tier price was $19/mo but tier-config.ts displays $29/mo — users would see a different price than what's charged
- **WARNING** [FIXED] `CLAUDE.md`: CLAUDE.md referenced STRIPE_PRICE_ID_FREE env var but free tier uses stripePriceId: null — misleading setup instructions
- **INFO** [OPEN] `packages/billing/src/webhook-handler.ts`: TOCTOU race between SELECT check and INSERT for idempotency — two concurrent retries could both process. Acceptable because upsertSubscription is itself idempotent, and the primary key constraint prevents actual duplicate rows

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*