### PR TITLE
feat: Billing flow integration tests (closes #64)

### DIFF
--- a/packages/billing/src/billing-flows.test.ts
+++ b/packages/billing/src/billing-flows.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ——— System boundary mocks ———
+
+const mockConstructEvent = vi.fn();
+vi.mock("./stripe-client", () => ({
+  getStripe: () => ({
+    webhooks: { constructEvent: mockConstructEvent },
+  }),
+}));
+
+const mockUpsertSubscription = vi.fn();
+const mockGetSubscription = vi.fn();
+vi.mock("./subscriptions", () => ({
+  upsertSubscription: (...args: unknown[]) => mockUpsertSubscription(...args),
+  getSubscription: (...args: unknown[]) => mockGetSubscription(...args),
+}));
+
+const mockEq = vi.fn(() => Promise.resolve({ data: null }));
+const mockUpdate = vi.fn(() => ({ eq: mockEq }));
+const mockFrom = vi.fn(() => ({ update: mockUpdate }));
+vi.mock("@repo/db/service-role", () => ({
+  createServiceRoleClient: () => ({ from: mockFrom }),
+}));
+
+import { handleStripeWebhook } from "./webhook-handler";
+import { hasFeatureAccess } from "./has-feature-access";
+
+describe("Billing flow integration tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("STRIPE_WEBHOOK_SECRET", "whsec_test");
+    mockUpsertSubscription.mockResolvedValue(undefined);
+  });
+
+  describe("Webhook event handling", () => {
+    it("handles customer.subscription.created", async () => {
+      const subscription = {
+        id: "sub_123",
+        customer: "cus_456",
+        status: "active",
+        items: { data: [{ price: { metadata: { tier: "pro" } } }] },
+        current_period_start: 1700000000,
+        current_period_end: 1702592000,
+      };
+      mockConstructEvent.mockReturnValue({
+        type: "customer.subscription.created",
+        data: { object: subscription },
+      });
+
+      const result = await handleStripeWebhook("body", "sig");
+
+      expect(result).toEqual({ received: true });
+      expect(mockUpsertSubscription).toHaveBeenCalledWith(subscription);
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it("handles customer.subscription.updated", async () => {
+      const subscription = {
+        id: "sub_123",
+        customer: "cus_456",
+        status: "active",
+        items: { data: [{ price: { metadata: { tier: "pro" } } }] },
+        current_period_start: 1700000000,
+        current_period_end: 1702592000,
+      };
+      mockConstructEvent.mockReturnValue({
+        type: "customer.subscription.updated",
+        data: { object: subscription },
+      });
+
+      const result = await handleStripeWebhook("body", "sig");
+
+      expect(result).toEqual({ received: true });
+      expect(mockUpsertSubscription).toHaveBeenCalledWith(subscription);
+    });
+
+    it("handles customer.subscription.deleted", async () => {
+      const subscription = { id: "sub_789", customer: "cus_456" };
+      mockConstructEvent.mockReturnValue({
+        type: "customer.subscription.deleted",
+        data: { object: subscription },
+      });
+
+      const result = await handleStripeWebhook("body", "sig");
+
+      expect(result).toEqual({ received: true });
+      expect(mockUpsertSubscription).not.toHaveBeenCalled();
+      expect(mockFrom).toHaveBeenCalledWith("subscriptions");
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "canceled" }),
+      );
+    });
+  });
+
+  describe("Subscription lifecycle: create → active → cancel", () => {
+    it("processes full subscription lifecycle in order", async () => {
+      const baseSubscription = {
+        id: "sub_lifecycle",
+        customer: "cus_lifecycle",
+        current_period_start: 1700000000,
+        current_period_end: 1702592000,
+        items: { data: [{ price: { metadata: { tier: "pro" } } }] },
+      };
+
+      mockConstructEvent
+        .mockReturnValueOnce({
+          type: "customer.subscription.created",
+          data: { object: { ...baseSubscription, status: "trialing" } },
+        })
+        .mockReturnValueOnce({
+          type: "customer.subscription.updated",
+          data: { object: { ...baseSubscription, status: "active" } },
+        })
+        .mockReturnValueOnce({
+          type: "customer.subscription.deleted",
+          data: { object: { id: "sub_lifecycle", customer: "cus_lifecycle" } },
+        });
+
+      await handleStripeWebhook("body1", "sig1");
+      expect(mockUpsertSubscription).toHaveBeenCalledTimes(1);
+      expect(mockUpsertSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "trialing" }),
+      );
+
+      await handleStripeWebhook("body2", "sig2");
+      expect(mockUpsertSubscription).toHaveBeenCalledTimes(2);
+      expect(mockUpsertSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "active" }),
+      );
+
+      await handleStripeWebhook("body3", "sig3");
+      expect(mockUpsertSubscription).toHaveBeenCalledTimes(2);
+      expect(mockFrom).toHaveBeenCalledWith("subscriptions");
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "canceled" }),
+      );
+    });
+  });
+
+  describe("hasFeatureAccess with subscription status", () => {
+    it("returns true for active pro user accessing pro feature", async () => {
+      mockGetSubscription.mockResolvedValue({ tier: "pro", status: "active" });
+      expect(await hasFeatureAccess("user-1", "advanced")).toBe(true);
+    });
+
+    it("returns false for free user accessing pro feature", async () => {
+      mockGetSubscription.mockResolvedValue({ tier: "free", status: "active" });
+      expect(await hasFeatureAccess("user-1", "advanced")).toBe(false);
+    });
+
+    it("returns true for trialing subscription", async () => {
+      mockGetSubscription.mockResolvedValue({ tier: "pro", status: "trialing" });
+      expect(await hasFeatureAccess("user-1", "advanced")).toBe(true);
+    });
+
+    it("returns false for past_due subscription", async () => {
+      mockGetSubscription.mockResolvedValue({ tier: "pro", status: "past_due" });
+      expect(await hasFeatureAccess("user-1", "advanced")).toBe(false);
+    });
+  });
+});

--- a/packages/billing/src/has-feature-access.test.ts
+++ b/packages/billing/src/has-feature-access.test.ts
@@ -13,22 +13,22 @@ describe("hasFeatureAccess", () => {
   });
 
   it("grants free users access to basic features", async () => {
-    mockGetSubscription.mockResolvedValue({ tier: "free" });
+    mockGetSubscription.mockResolvedValue({ tier: "free", status: "active" });
     expect(await hasFeatureAccess("user-1", "basic")).toBe(true);
   });
 
   it("denies free users access to pro features", async () => {
-    mockGetSubscription.mockResolvedValue({ tier: "free" });
+    mockGetSubscription.mockResolvedValue({ tier: "free", status: "active" });
     expect(await hasFeatureAccess("user-1", "advanced")).toBe(false);
   });
 
   it("grants pro users access to pro features", async () => {
-    mockGetSubscription.mockResolvedValue({ tier: "pro" });
+    mockGetSubscription.mockResolvedValue({ tier: "pro", status: "active" });
     expect(await hasFeatureAccess("user-1", "advanced")).toBe(true);
   });
 
   it("grants enterprise users access to all features", async () => {
-    mockGetSubscription.mockResolvedValue({ tier: "enterprise" });
+    mockGetSubscription.mockResolvedValue({ tier: "enterprise", status: "active" });
     expect(await hasFeatureAccess("user-1", "basic")).toBe(true);
     expect(await hasFeatureAccess("user-1", "advanced")).toBe(true);
     expect(await hasFeatureAccess("user-1", "custom")).toBe(true);
@@ -41,7 +41,22 @@ describe("hasFeatureAccess", () => {
   });
 
   it("returns false for unknown features", async () => {
-    mockGetSubscription.mockResolvedValue({ tier: "enterprise" });
+    mockGetSubscription.mockResolvedValue({ tier: "enterprise", status: "active" });
     expect(await hasFeatureAccess("user-1", "nonexistent")).toBe(false);
+  });
+
+  it("returns true for active pro user accessing pro feature", async () => {
+    mockGetSubscription.mockResolvedValue({ tier: "pro", status: "active" });
+    expect(await hasFeatureAccess("user-1", "advanced")).toBe(true);
+  });
+
+  it("returns true for trialing subscription", async () => {
+    mockGetSubscription.mockResolvedValue({ tier: "pro", status: "trialing" });
+    expect(await hasFeatureAccess("user-1", "advanced")).toBe(true);
+  });
+
+  it("returns false for past_due subscription", async () => {
+    mockGetSubscription.mockResolvedValue({ tier: "pro", status: "past_due" });
+    expect(await hasFeatureAccess("user-1", "advanced")).toBe(false);
   });
 });

--- a/packages/billing/src/has-feature-access.ts
+++ b/packages/billing/src/has-feature-access.ts
@@ -1,4 +1,4 @@
-import type { Tier } from "./types";
+import type { Tier, SubscriptionStatus } from "./types";
 import { getSubscription } from "./subscriptions";
 
 const TIER_RANK: Record<Tier, number> = {
@@ -13,6 +13,8 @@ const FEATURE_TIER: Record<string, Tier> = {
   custom: "enterprise",
 };
 
+const ALLOWED_STATUSES = new Set<SubscriptionStatus>(["active", "trialing"]);
+
 export async function hasFeatureAccess(
   userId: string,
   feature: string,
@@ -21,6 +23,11 @@ export async function hasFeatureAccess(
   if (!requiredTier) return false;
 
   const subscription = await getSubscription(userId);
+
+  if (subscription && !ALLOWED_STATUSES.has(subscription.status)) {
+    return false;
+  }
+
   const userTier: Tier = subscription?.tier ?? "free";
 
   return TIER_RANK[userTier] >= TIER_RANK[requiredTier];


### PR DESCRIPTION
Closes #64

## Summary

Automated implementation of **Billing flow integration tests**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |
| Details | 117 passed |

## Code Review

All 8 acceptance criteria met; billing integration tests and hasFeatureAccess status gating are correct and passing.

- **INFO** [OPEN] `packages/billing/src/has-feature-access.test.ts`: has-feature-access.test.ts line 48 ('returns true for active pro user accessing pro feature') is a duplicate of line 23 ('grants pro users access to pro features') — identical mock and assertion

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*