### PR TITLE
feat: app registry integrity tests (closes #66)

### DIFF
--- a/apps/web/lib/__tests__/app-registry.test.ts
+++ b/apps/web/lib/__tests__/app-registry.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import {
   getAppBySubdomain,
   getAppBySlug,
@@ -95,5 +97,37 @@ describe("app-registry", () => {
       expect(typeof app.features).toBe("object");
       expect(app.features).not.toBeNull();
     }
+  });
+
+  describe("registry integrity", () => {
+    it("no duplicate slugs", () => {
+      const apps = getAllApps();
+      const slugs = apps.map((a) => a.slug);
+      expect(new Set(slugs).size).toBe(slugs.length);
+    });
+
+    it("no duplicate subdomains", () => {
+      const apps = getAllApps();
+      const subdomains = apps.map((a) => a.subdomain);
+      expect(new Set(subdomains).size).toBe(subdomains.length);
+    });
+
+    it("every routeGroup maps to an existing directory", () => {
+      const apps = getAllApps();
+      for (const app of apps) {
+        const dir = path.resolve(__dirname, "../../app", app.routeGroup);
+        expect(fs.existsSync(dir), `Missing directory for ${app.slug}: ${dir}`).toBe(true);
+      }
+    });
+
+    it("every auth-gated app has a layout calling requireAppLayoutAccess", () => {
+      const apps = getAllApps();
+      for (const app of apps.filter((a) => a.auth)) {
+        const layoutPath = path.resolve(__dirname, "../../app", app.routeGroup, "layout.tsx");
+        expect(fs.existsSync(layoutPath), `Missing layout for ${app.slug}: ${layoutPath}`).toBe(true);
+        const contents = fs.readFileSync(layoutPath, "utf-8");
+        expect(contents, `${app.slug} layout missing requireAppLayoutAccess`).toContain("requireAppLayoutAccess");
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds a `registry integrity` describe block to `apps/web/lib/__tests__/app-registry.test.ts` asserting no duplicate slugs, no duplicate subdomains, every `routeGroup` maps to an existing directory, and every auth-gated app layout calls `requireAppLayoutAccess`.

Closes #66.

## Test plan
- [x] `pnpm --filter @repo/web test` — 732/732 pass (19 in `app-registry.test.ts`)

## Notes
Rebased from the original `agent/issue-66` branch onto current `main`. Dropped three noise commits that were stale against current `main`:
- A vitest `watch:false` workaround (main already uses `vitest run`).
- A `tsconfig.tsbuildinfo` tweak (build artifact).
- A pnpm-lock churn commit (no `package.json` changes remained after rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)