### PR TITLE
feat: batch implementation (#160, #161, #162, #163, #164)

### DIFF
--- a/apps/web/__tests__/proxy.integration.test.ts
+++ b/apps/web/__tests__/proxy.integration.test.ts
@@ -231,6 +231,51 @@ describe("proxy middleware integration", () => {
     });
   });
 
+  describe("CSRF protection", () => {
+    it("returns 403 for POST /api/checkout/session without a csrf token", async () => {
+      const req = new NextRequest(
+        "https://apps.lastrev.com/api/checkout/session",
+        { method: "POST", headers: { host: "apps.lastrev.com" } },
+      );
+      const res = await proxy(req);
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("csrf_invalid");
+    });
+
+    it("skips CSRF check for the stripe webhook", async () => {
+      const req = new NextRequest(
+        "https://apps.lastrev.com/api/webhooks/stripe",
+        { method: "POST", headers: { host: "apps.lastrev.com" } },
+      );
+      const res = await proxy(req);
+      expect(res.status).not.toBe(403);
+    });
+
+    it("sets a csrf_token cookie on safe GET responses", async () => {
+      const req = makeRequest(
+        "https://apps.lastrev.com/my-apps",
+        "apps.lastrev.com",
+      );
+      const res = await proxy(req);
+      const setCookie = res.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain("csrf_token=");
+    });
+
+    it("does not overwrite an existing csrf_token cookie", async () => {
+      const req = new NextRequest("https://apps.lastrev.com/my-apps", {
+        headers: {
+          host: "apps.lastrev.com",
+          cookie: "csrf_token=already-here",
+        },
+      });
+      const res = await proxy(req);
+      const setCookie = res.headers.get("set-cookie") ?? "";
+      // The auth mock always sets appSession, but we should not see a new csrf_token.
+      expect(setCookie).not.toMatch(/csrf_token=(?!already-here)/);
+    });
+  });
+
   describe("subdomain resolution across all registered apps", () => {
     it("produces a rewrite for every registered subdomain", async () => {
       vi.stubEnv("NODE_ENV", "production");

--- a/apps/web/__tests__/proxy.integration.test.ts
+++ b/apps/web/__tests__/proxy.integration.test.ts
@@ -11,6 +11,7 @@ vi.mock("@repo/auth/auth0-factory", () => ({
 
 import { proxy } from "../proxy";
 import { getAuth0ClientForHost } from "@repo/auth/auth0-factory";
+import { _resetRateLimitStore } from "../lib/rate-limit";
 
 const mockedGetAuth0 = vi.mocked(getAuth0ClientForHost);
 
@@ -29,6 +30,7 @@ describe("proxy middleware integration", () => {
     middlewareMock.mockReset();
     middlewareMock.mockImplementation(async () => freshAuthResponse());
     mockedGetAuth0.mockClear();
+    _resetRateLimitStore();
   });
 
   afterEach(() => {
@@ -131,6 +133,28 @@ describe("proxy middleware integration", () => {
       const res = await proxy(req);
       expect(res.headers.get("x-auth-marker")).toBe("from-auth0");
       expect(res.headers.get("x-middleware-rewrite")).toBeFalsy();
+    });
+
+    it("rate-limits /auth/* to 10 requests per IP per minute", async () => {
+      for (let i = 0; i < 10; i++) {
+        const req = makeRequest(
+          "https://auth.lastrev.com/auth/callback",
+          "auth.lastrev.com",
+        );
+        req.headers.set("x-forwarded-for", "7.7.7.7");
+        const res = await proxy(req);
+        expect(res.status).toBeLessThan(400);
+        expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+      }
+      const req = makeRequest(
+        "https://auth.lastrev.com/auth/callback",
+        "auth.lastrev.com",
+      );
+      req.headers.set("x-forwarded-for", "7.7.7.7");
+      const blocked = await proxy(req);
+      expect(blocked.status).toBe(429);
+      expect(blocked.headers.get("X-RateLimit-Remaining")).toBe("0");
+      expect(blocked.headers.get("Retry-After")).toBeTruthy();
     });
   });
 

--- a/apps/web/app/api/checkout/session/__tests__/route.test.ts
+++ b/apps/web/app/api/checkout/session/__tests__/route.test.ts
@@ -37,10 +37,20 @@ vi.mock("@repo/db/service-role", () => ({
   createServiceRoleClient: vi.fn().mockReturnValue({}),
 }));
 
-function makeRequest(body: unknown): Request {
+const CSRF_VALUE = "test-csrf-token";
+
+function makeRequest(
+  body: unknown,
+  options: { csrfCookie?: string | null; csrfHeader?: string | null } = {},
+): Request {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const cookieVal = options.csrfCookie === undefined ? CSRF_VALUE : options.csrfCookie;
+  const headerVal = options.csrfHeader === undefined ? CSRF_VALUE : options.csrfHeader;
+  if (cookieVal !== null) headers["cookie"] = `csrf_token=${cookieVal}`;
+  if (headerVal !== null) headers["x-csrf-token"] = headerVal;
   return new Request("http://localhost/api/checkout/session", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(body),
   });
 }
@@ -165,7 +175,11 @@ describe("POST /api/checkout/session", () => {
     const { POST } = await import("../route");
     const req = new Request("http://localhost/api/checkout/session", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        cookie: `csrf_token=${CSRF_VALUE}`,
+        "x-csrf-token": CSRF_VALUE,
+      },
       body: "not-json",
     });
 
@@ -174,5 +188,36 @@ describe("POST /api/checkout/session", () => {
     expect(res.status).toBe(400);
     const data = (await res.json()) as { error: string };
     expect(data.error).toBe("invalid_json");
+  });
+
+  it("returns 403 csrf_invalid when the csrf cookie is missing", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { sub: "user_1", email: "user@example.com" },
+    });
+    const { POST } = await import("../route");
+
+    const res = await POST(
+      makeRequest({ priceId: "price_pro_monthly" }, { csrfCookie: null }),
+    );
+
+    expect(res.status).toBe(403);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toBe("csrf_invalid");
+  });
+
+  it("returns 403 csrf_invalid when header and cookie mismatch", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { sub: "user_1", email: "user@example.com" },
+    });
+    const { POST } = await import("../route");
+
+    const res = await POST(
+      makeRequest(
+        { priceId: "price_pro_monthly" },
+        { csrfHeader: "different-token" },
+      ),
+    );
+
+    expect(res.status).toBe(403);
   });
 });

--- a/apps/web/app/api/checkout/session/__tests__/route.test.ts
+++ b/apps/web/app/api/checkout/session/__tests__/route.test.ts
@@ -28,6 +28,15 @@ vi.mock("@repo/billing", () => ({
   }),
 }));
 
+// ── Mock @repo/db for audit logging ───────────────────────────────────────────
+const mockLogAuditEvent = vi.fn().mockResolvedValue(undefined);
+vi.mock("@repo/db/audit", () => ({
+  logAuditEvent: (...args: unknown[]) => mockLogAuditEvent(...args),
+}));
+vi.mock("@repo/db/service-role", () => ({
+  createServiceRoleClient: vi.fn().mockReturnValue({}),
+}));
+
 function makeRequest(body: unknown): Request {
   return new Request("http://localhost/api/checkout/session", {
     method: "POST",
@@ -72,6 +81,7 @@ describe("POST /api/checkout/session", () => {
     });
     mockGetOrCreateCustomer.mockResolvedValue("cus_abc123");
     mockCheckoutSessionsCreate.mockResolvedValue({
+      id: "cs_test_abc",
       url: "https://checkout.stripe.com/pay/cs_test_abc",
     });
     const { POST } = await import("../route");
@@ -81,6 +91,15 @@ describe("POST /api/checkout/session", () => {
     expect(res.status).toBe(200);
     const data = await res.json() as { checkoutUrl: string };
     expect(data.checkoutUrl).toBe("https://checkout.stripe.com/pay/cs_test_abc");
+    expect(mockLogAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        userId: "user_1",
+        action: "checkout.session.created",
+        resource: "cs_test_abc",
+        metadata: { priceId: "price_pro_monthly" },
+      }),
+    );
   });
 
   it("passes correct customer ID and price to Stripe", async () => {

--- a/apps/web/app/api/checkout/session/__tests__/route.test.ts
+++ b/apps/web/app/api/checkout/session/__tests__/route.test.ts
@@ -62,7 +62,7 @@ describe("POST /api/checkout/session", () => {
     expect(data.error).toBe("Unauthorized");
   });
 
-  it("returns 400 when priceId is missing", async () => {
+  it("returns 400 with invalid_input issues when priceId is missing", async () => {
     mockGetSession.mockResolvedValue({
       user: { sub: "user_1", email: "user@example.com" },
     });
@@ -71,8 +71,27 @@ describe("POST /api/checkout/session", () => {
     const res = await POST(makeRequest({}));
 
     expect(res.status).toBe(400);
-    const data = await res.json() as { error: string };
-    expect(data.error).toBe("Missing priceId");
+    const data = (await res.json()) as {
+      error: string;
+      issues: Array<{ path: unknown; message: string }>;
+    };
+    expect(data.error).toBe("invalid_input");
+    expect(data.issues).toBeInstanceOf(Array);
+    expect(data.issues.length).toBeGreaterThan(0);
+    expect(data.issues[0]?.path).toContain("priceId");
+  });
+
+  it("returns 400 with invalid_input when priceId is empty string", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { sub: "user_1", email: "user@example.com" },
+    });
+    const { POST } = await import("../route");
+
+    const res = await POST(makeRequest({ priceId: "" }));
+
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toBe("invalid_input");
   });
 
   it("creates checkout session and returns checkoutUrl", async () => {
@@ -139,7 +158,7 @@ describe("POST /api/checkout/session", () => {
     expect(data.error).toBe("Stripe error");
   });
 
-  it("returns 400 when request body is not valid JSON", async () => {
+  it("returns 400 invalid_json when request body is not valid JSON", async () => {
     mockGetSession.mockResolvedValue({
       user: { sub: "user_1", email: "user@example.com" },
     });
@@ -153,7 +172,7 @@ describe("POST /api/checkout/session", () => {
     const res = await POST(req);
 
     expect(res.status).toBe(400);
-    const data = await res.json() as { error: string };
-    expect(data.error).toBe("Invalid request body");
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toBe("invalid_json");
   });
 });

--- a/apps/web/app/api/checkout/session/route.ts
+++ b/apps/web/app/api/checkout/session/route.ts
@@ -9,6 +9,7 @@ import { logAuditEvent } from "@repo/db/audit";
 import { createServiceRoleClient } from "@repo/db/service-role";
 import { log, withRequestContext } from "@repo/logger";
 import { validateJson } from "@/lib/validate-request";
+import { csrfFailureResponse, validateCsrf } from "@/lib/csrf";
 
 const checkoutSchema = z.object({
   priceId: z.string().min(1),
@@ -19,6 +20,12 @@ export async function POST(request: Request): Promise<Response> {
   return withRequestContext(
     { requestId, route: "checkout-session" },
     async () => {
+      const csrf = validateCsrf(request);
+      if (!csrf.ok) {
+        log.warn("checkout session csrf_invalid", { reason: csrf.reason });
+        return csrfFailureResponse(csrf.reason);
+      }
+
       const h = await headers();
       const host = getHostFromRequestHeaders(h);
       const auth0 = getAuth0ClientForHost(host);

--- a/apps/web/app/api/checkout/session/route.ts
+++ b/apps/web/app/api/checkout/session/route.ts
@@ -1,4 +1,5 @@
 import { headers } from "next/headers";
+import { z } from "zod";
 import { getOrCreateCustomer, getStripe } from "@repo/billing";
 import {
   getAuth0ClientForHost,
@@ -7,6 +8,11 @@ import {
 import { logAuditEvent } from "@repo/db/audit";
 import { createServiceRoleClient } from "@repo/db/service-role";
 import { log, withRequestContext } from "@repo/logger";
+import { validateJson } from "@/lib/validate-request";
+
+const checkoutSchema = z.object({
+  priceId: z.string().min(1),
+});
 
 export async function POST(request: Request): Promise<Response> {
   const requestId = crypto.randomUUID();
@@ -27,22 +33,12 @@ export async function POST(request: Request): Promise<Response> {
       const email =
         typeof session.user.email === "string" ? session.user.email : "";
 
-      let body: { priceId: string };
-      try {
-        body = (await request.json()) as { priceId: string };
-      } catch {
-        log.warn("checkout session invalid body", { userId });
-        return Response.json(
-          { error: "Invalid request body" },
-          { status: 400 },
-        );
+      const validated = await validateJson(request, checkoutSchema);
+      if (!validated.ok) {
+        log.warn("checkout session invalid input", { userId });
+        return validated.response;
       }
-
-      const { priceId } = body;
-      if (!priceId) {
-        log.warn("checkout session missing priceId", { userId });
-        return Response.json({ error: "Missing priceId" }, { status: 400 });
-      }
+      const { priceId } = validated.data;
 
       const appUrl = process.env.APP_BASE_URL ?? "http://localhost:3000";
 

--- a/apps/web/app/api/checkout/session/route.ts
+++ b/apps/web/app/api/checkout/session/route.ts
@@ -4,6 +4,8 @@ import {
   getAuth0ClientForHost,
   getHostFromRequestHeaders,
 } from "@repo/auth/auth0-factory";
+import { logAuditEvent } from "@repo/db/audit";
+import { createServiceRoleClient } from "@repo/db/service-role";
 import { log, withRequestContext } from "@repo/logger";
 
 export async function POST(request: Request): Promise<Response> {
@@ -56,6 +58,12 @@ export async function POST(request: Request): Promise<Response> {
         });
 
         log.info("checkout session created", { userId, priceId });
+        await logAuditEvent(createServiceRoleClient(), {
+          userId,
+          action: "checkout.session.created",
+          resource: checkoutSession.id ?? null,
+          metadata: { priceId },
+        });
         return Response.json({ checkoutUrl: checkoutSession.url });
       } catch (err) {
         log.error("checkout session failed", { err, userId, priceId });

--- a/apps/web/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "./route";
+import { _resetRateLimitStore } from "@/lib/rate-limit";
 
 const mockHandleStripeWebhook = vi.fn();
 vi.mock("@repo/billing/webhook-handler", () => ({
@@ -17,6 +18,7 @@ function makeRequest(body: string, headers: Record<string, string> = {}): Reques
 describe("POST /api/webhooks/stripe", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetRateLimitStore();
   });
 
   it("returns 200 with { received: true } on valid signature", async () => {
@@ -62,5 +64,31 @@ describe("POST /api/webhooks/stripe", () => {
     expect(Buffer.isBuffer(body)).toBe(true);
     expect(body.toString()).toBe("raw-body");
     expect(signature).toBe("sig_test");
+  });
+
+  it("includes X-RateLimit headers on successful response", async () => {
+    mockHandleStripeWebhook.mockResolvedValue({ received: true });
+    const request = makeRequest("payload", {
+      "stripe-signature": "sig_ok",
+      "x-forwarded-for": "9.9.9.9",
+    });
+    const response = await POST(request);
+
+    expect(response.headers.get("X-RateLimit-Limit")).toBe("100");
+    expect(response.headers.get("X-RateLimit-Remaining")).toBe("99");
+    expect(response.headers.get("X-RateLimit-Reset")).toBeTruthy();
+  });
+
+  it("returns 429 after exceeding the webhook rate limit", async () => {
+    mockHandleStripeWebhook.mockResolvedValue({ received: true });
+    const headers = { "stripe-signature": "sig_ok", "x-forwarded-for": "8.8.8.8" };
+    for (let i = 0; i < 100; i++) {
+      const res = await POST(makeRequest("payload", headers));
+      expect(res.status).toBe(200);
+    }
+    const blocked = await POST(makeRequest("payload", headers));
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("Retry-After")).toBeTruthy();
+    expect(blocked.headers.get("X-RateLimit-Remaining")).toBe("0");
   });
 });

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { handleStripeWebhook } from "@repo/billing/webhook-handler";
 import { log, withRequestContext } from "@repo/logger";
 import {
@@ -9,6 +10,13 @@ import {
 
 const WEBHOOK_RATE_LIMIT = 100;
 const WEBHOOK_RATE_WINDOW_MS = 60_000;
+
+// Stripe sends the event as a raw Buffer (required for signature verification),
+// so we validate the header envelope only. Any future JSON fields we add to
+// this route should use validateJson from @/lib/validate-request.
+const headerSchema = z.object({
+  "stripe-signature": z.string().min(1),
+});
 
 export async function POST(request: Request): Promise<Response> {
   const requestId = crypto.randomUUID();
@@ -26,9 +34,11 @@ export async function POST(request: Request): Promise<Response> {
         return rateLimitResponse(rateLimitResult);
       }
 
-      const signature = request.headers.get("stripe-signature");
+      const headerCheck = headerSchema.safeParse({
+        "stripe-signature": request.headers.get("stripe-signature"),
+      });
 
-      if (!signature) {
+      if (!headerCheck.success) {
         log.warn("stripe webhook missing signature header");
         return applyRateLimitHeaders(
           Response.json(
@@ -38,6 +48,8 @@ export async function POST(request: Request): Promise<Response> {
           rateLimitResult,
         );
       }
+
+      const signature = headerCheck.data["stripe-signature"];
 
       const arrayBuffer = await request.arrayBuffer();
       const body = Buffer.from(arrayBuffer);

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,18 +1,41 @@
 import { handleStripeWebhook } from "@repo/billing/webhook-handler";
 import { log, withRequestContext } from "@repo/logger";
+import {
+  applyRateLimitHeaders,
+  getClientIp,
+  rateLimit,
+  rateLimitResponse,
+} from "@/lib/rate-limit";
+
+const WEBHOOK_RATE_LIMIT = 100;
+const WEBHOOK_RATE_WINDOW_MS = 60_000;
 
 export async function POST(request: Request): Promise<Response> {
   const requestId = crypto.randomUUID();
   return withRequestContext(
     { requestId, route: "stripe-webhook" },
     async () => {
+      const ip = getClientIp(request.headers);
+      const rateLimitResult = rateLimit(
+        `webhook:${ip}`,
+        WEBHOOK_RATE_LIMIT,
+        WEBHOOK_RATE_WINDOW_MS,
+      );
+      if (!rateLimitResult.allowed) {
+        log.warn("stripe webhook rate limited", { ip });
+        return rateLimitResponse(rateLimitResult);
+      }
+
       const signature = request.headers.get("stripe-signature");
 
       if (!signature) {
         log.warn("stripe webhook missing signature header");
-        return Response.json(
-          { error: "Missing stripe-signature header" },
-          { status: 400 },
+        return applyRateLimitHeaders(
+          Response.json(
+            { error: "Missing stripe-signature header" },
+            { status: 400 },
+          ),
+          rateLimitResult,
         );
       }
 
@@ -22,11 +45,17 @@ export async function POST(request: Request): Promise<Response> {
       try {
         const result = await handleStripeWebhook(body, signature);
         log.info("stripe webhook processed");
-        return Response.json(result, { status: 200 });
+        return applyRateLimitHeaders(
+          Response.json(result, { status: 200 }),
+          rateLimitResult,
+        );
       } catch (err) {
         log.error("stripe webhook failed", { err });
         const message = err instanceof Error ? err.message : "Unknown error";
-        return Response.json({ error: message }, { status: 400 });
+        return applyRateLimitHeaders(
+          Response.json({ error: message }, { status: 400 }),
+          rateLimitResult,
+        );
       }
     },
   );

--- a/apps/web/lib/__tests__/csp.test.ts
+++ b/apps/web/lib/__tests__/csp.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { NextResponse } from "next/server";
+import {
+  buildCspHeader,
+  applyCspHeader,
+  cspHeaderName,
+  isReportOnly,
+} from "../csp";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("buildCspHeader", () => {
+  it("includes the standard directives", () => {
+    const header = buildCspHeader();
+    expect(header).toContain("default-src 'self'");
+    expect(header).toContain("frame-ancestors 'none'");
+    expect(header).toContain("base-uri 'self'");
+    expect(header).toContain("form-action 'self'");
+    expect(header).toContain("img-src 'self' data: blob:");
+  });
+
+  it("blocks 'unsafe-inline' for script-src in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const header = buildCspHeader();
+    const scriptSrc = header.split(";").find((d) => d.trim().startsWith("script-src"));
+    expect(scriptSrc).toBeDefined();
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    expect(scriptSrc).toContain("'self'");
+  });
+
+  it("allows 'unsafe-inline' for script-src outside production", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const header = buildCspHeader();
+    const scriptSrc = header.split(";").find((d) => d.trim().startsWith("script-src"));
+    expect(scriptSrc).toContain("'unsafe-inline'");
+  });
+
+  it("merges connect-src hosts from .csp-defaults.json", () => {
+    const header = buildCspHeader();
+    expect(header).toContain("https://fzmhqcgzvgtvkswpwruc.supabase.co");
+    expect(header).toContain("https://lregiwsovpmljxjvrrsc.supabase.co");
+    expect(header).toContain("https://*.auth0.com");
+  });
+});
+
+describe("cspHeaderName / isReportOnly", () => {
+  it("uses Content-Security-Policy by default", () => {
+    expect(cspHeaderName(false)).toBe("Content-Security-Policy");
+  });
+
+  it("switches to report-only when CSP_REPORT_ONLY=true", () => {
+    vi.stubEnv("CSP_REPORT_ONLY", "true");
+    expect(isReportOnly()).toBe(true);
+    expect(cspHeaderName()).toBe("Content-Security-Policy-Report-Only");
+  });
+
+  it("treats CSP_REPORT_ONLY=1 as truthy", () => {
+    vi.stubEnv("CSP_REPORT_ONLY", "1");
+    expect(isReportOnly()).toBe(true);
+  });
+});
+
+describe("applyCspHeader", () => {
+  it("sets the CSP header on the response", () => {
+    const res = NextResponse.next();
+    applyCspHeader(res);
+    expect(res.headers.get("Content-Security-Policy")).toBeTruthy();
+  });
+
+  it("uses the report-only header name when configured", () => {
+    vi.stubEnv("CSP_REPORT_ONLY", "true");
+    const res = NextResponse.next();
+    applyCspHeader(res);
+    expect(res.headers.get("Content-Security-Policy")).toBeNull();
+    expect(res.headers.get("Content-Security-Policy-Report-Only")).toBeTruthy();
+  });
+});

--- a/apps/web/lib/__tests__/csrf.test.ts
+++ b/apps/web/lib/__tests__/csrf.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CSRF_COOKIE,
+  CSRF_HEADER,
+  ensureCsrfCookie,
+  generateCsrfToken,
+  shouldValidateCsrf,
+  validateCsrf,
+} from "../csrf";
+
+function buildNextRequest(
+  url: string,
+  init: { method?: string; cookies?: Record<string, string>; headers?: Record<string, string> } = {},
+): NextRequest {
+  const headers = new Headers(init.headers);
+  if (init.cookies) {
+    const serialized = Object.entries(init.cookies)
+      .map(([k, v]) => `${k}=${v}`)
+      .join("; ");
+    headers.set("cookie", serialized);
+  }
+  return new NextRequest(url, { method: init.method ?? "GET", headers });
+}
+
+describe("generateCsrfToken", () => {
+  it("produces unique tokens of at least 32 chars", () => {
+    const a = generateCsrfToken();
+    const b = generateCsrfToken();
+    expect(a).not.toBe(b);
+    expect(a.length).toBeGreaterThanOrEqual(32);
+    expect(b.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it("produces url-safe base64 characters only", () => {
+    const token = generateCsrfToken();
+    expect(/^[A-Za-z0-9_-]+$/.test(token)).toBe(true);
+  });
+});
+
+describe("validateCsrf", () => {
+  it("allows safe methods without token", () => {
+    const req = buildNextRequest("https://host.test/api/x", { method: "GET" });
+    expect(validateCsrf(req)).toEqual({ ok: true });
+  });
+
+  it("rejects POST with no cookie", () => {
+    const req = buildNextRequest("https://host.test/api/x", {
+      method: "POST",
+      headers: { [CSRF_HEADER]: "tok" },
+    });
+    expect(validateCsrf(req)).toEqual({ ok: false, reason: "missing_cookie" });
+  });
+
+  it("rejects POST with cookie but no header", () => {
+    const req = buildNextRequest("https://host.test/api/x", {
+      method: "POST",
+      cookies: { [CSRF_COOKIE]: "tok" },
+    });
+    expect(validateCsrf(req)).toEqual({ ok: false, reason: "missing_header" });
+  });
+
+  it("rejects mismatched token", () => {
+    const req = buildNextRequest("https://host.test/api/x", {
+      method: "POST",
+      cookies: { [CSRF_COOKIE]: "tok" },
+      headers: { [CSRF_HEADER]: "different" },
+    });
+    expect(validateCsrf(req)).toEqual({ ok: false, reason: "mismatch" });
+  });
+
+  it("accepts matching cookie + header", () => {
+    const token = "abc123";
+    const req = buildNextRequest("https://host.test/api/x", {
+      method: "POST",
+      cookies: { [CSRF_COOKIE]: token },
+      headers: { [CSRF_HEADER]: token },
+    });
+    expect(validateCsrf(req)).toEqual({ ok: true });
+  });
+});
+
+describe("shouldValidateCsrf", () => {
+  it("skips GET requests", () => {
+    const req = buildNextRequest("https://host.test/api/checkout/session", {
+      method: "GET",
+    });
+    expect(shouldValidateCsrf(req)).toBe(false);
+  });
+
+  it("skips non-API paths", () => {
+    const req = buildNextRequest("https://host.test/dashboard", {
+      method: "POST",
+    });
+    expect(shouldValidateCsrf(req)).toBe(false);
+  });
+
+  it("skips the stripe webhook (signature-verified instead)", () => {
+    const req = buildNextRequest("https://host.test/api/webhooks/stripe", {
+      method: "POST",
+    });
+    expect(shouldValidateCsrf(req)).toBe(false);
+  });
+
+  it("validates POST to /api/checkout/session", () => {
+    const req = buildNextRequest("https://host.test/api/checkout/session", {
+      method: "POST",
+    });
+    expect(shouldValidateCsrf(req)).toBe(true);
+  });
+});
+
+describe("ensureCsrfCookie", () => {
+  it("sets a csrf_token cookie on the response when none exists", () => {
+    const req = buildNextRequest("https://host.test/");
+    const res = NextResponse.next();
+    ensureCsrfCookie(res, req);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toMatch(new RegExp(`${CSRF_COOKIE}=`));
+    expect(setCookie).toContain("Path=/");
+    expect(setCookie).toContain("SameSite=Lax");
+  });
+
+  it("does not set a new cookie when the request already has one", () => {
+    const req = buildNextRequest("https://host.test/", {
+      cookies: { [CSRF_COOKIE]: "already-set" },
+    });
+    const res = NextResponse.next();
+    ensureCsrfCookie(res, req);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).not.toMatch(new RegExp(`${CSRF_COOKIE}=`));
+  });
+});

--- a/apps/web/lib/__tests__/rate-limit.test.ts
+++ b/apps/web/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  _resetRateLimitStore,
+  getClientIp,
+  rateLimit,
+  rateLimitResponse,
+} from "../rate-limit";
+
+beforeEach(() => {
+  _resetRateLimitStore();
+});
+
+describe("rateLimit", () => {
+  it("allows up to the limit and then blocks", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 5; i++) {
+      const r = rateLimit("k", 5, 60_000, now);
+      expect(r.allowed).toBe(true);
+      expect(r.limit).toBe(5);
+      expect(r.remaining).toBe(4 - i);
+    }
+    const blocked = rateLimit("k", 5, 60_000, now);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.reset).toBe(now + 60_000);
+  });
+
+  it("resets the window after expiry", () => {
+    const t0 = 1_000_000;
+    rateLimit("k", 2, 60_000, t0);
+    rateLimit("k", 2, 60_000, t0);
+    expect(rateLimit("k", 2, 60_000, t0).allowed).toBe(false);
+
+    const t1 = t0 + 60_001;
+    const result = rateLimit("k", 2, 60_000, t1);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(1);
+    expect(result.reset).toBe(t1 + 60_000);
+  });
+
+  it("tracks different keys independently", () => {
+    const now = 1_000_000;
+    rateLimit("a", 1, 60_000, now);
+    const blockedA = rateLimit("a", 1, 60_000, now);
+    const freshB = rateLimit("b", 1, 60_000, now);
+    expect(blockedA.allowed).toBe(false);
+    expect(freshB.allowed).toBe(true);
+  });
+});
+
+describe("getClientIp", () => {
+  it("prefers the first entry in x-forwarded-for", () => {
+    const h = new Headers({ "x-forwarded-for": "1.2.3.4, 5.6.7.8" });
+    expect(getClientIp(h)).toBe("1.2.3.4");
+  });
+
+  it("falls back to x-real-ip", () => {
+    const h = new Headers({ "x-real-ip": "9.9.9.9" });
+    expect(getClientIp(h)).toBe("9.9.9.9");
+  });
+
+  it("returns unknown when neither header present", () => {
+    expect(getClientIp(new Headers())).toBe("unknown");
+  });
+});
+
+describe("rateLimitResponse", () => {
+  it("returns 429 with X-RateLimit-* and Retry-After headers", async () => {
+    const now = Date.now();
+    const response = rateLimitResponse({
+      allowed: false,
+      limit: 10,
+      remaining: 0,
+      reset: now + 30_000,
+    });
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("X-RateLimit-Limit")).toBe("10");
+    expect(response.headers.get("X-RateLimit-Remaining")).toBe("0");
+    expect(response.headers.get("X-RateLimit-Reset")).toBe(
+      String(Math.ceil((now + 30_000) / 1000)),
+    );
+    const retryAfter = Number(response.headers.get("Retry-After"));
+    expect(retryAfter).toBeGreaterThanOrEqual(29);
+    expect(retryAfter).toBeLessThanOrEqual(30);
+
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("rate_limited");
+  });
+});

--- a/apps/web/lib/__tests__/validate-request.test.ts
+++ b/apps/web/lib/__tests__/validate-request.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { validateJson } from "../validate-request";
+
+const schema = z.object({
+  email: z.string().email(),
+  count: z.number().int().positive(),
+});
+
+function jsonRequest(body: unknown): Request {
+  return new Request("http://localhost/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("validateJson", () => {
+  it("returns ok with typed data when input matches", async () => {
+    const result = await validateJson(
+      jsonRequest({ email: "a@b.co", count: 2 }),
+      schema,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({ email: "a@b.co", count: 2 });
+    }
+  });
+
+  it("returns 400 invalid_json on malformed JSON", async () => {
+    const result = await validateJson(jsonRequest("not-json"), schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(400);
+      const body = (await result.response.json()) as { error: string };
+      expect(body.error).toBe("invalid_json");
+    }
+  });
+
+  it("returns 400 invalid_input with structured issues on schema failure", async () => {
+    const result = await validateJson(
+      jsonRequest({ email: "nope", count: -1 }),
+      schema,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(400);
+      const body = (await result.response.json()) as {
+        error: string;
+        issues: Array<{ path: unknown; message: string; code: string }>;
+      };
+      expect(body.error).toBe("invalid_input");
+      expect(body.issues.length).toBeGreaterThanOrEqual(2);
+      const paths = body.issues.map((i) => JSON.stringify(i.path));
+      expect(paths.some((p) => p.includes("email"))).toBe(true);
+      expect(paths.some((p) => p.includes("count"))).toBe(true);
+    }
+  });
+});

--- a/apps/web/lib/csp.ts
+++ b/apps/web/lib/csp.ts
@@ -1,0 +1,56 @@
+import type { NextResponse } from "next/server";
+import cspDefaults from "../../.csp-defaults.json";
+
+type CspDefaults = {
+  csp?: {
+    connectSrc?: string[];
+  };
+};
+
+const CSP_HEADER = "Content-Security-Policy";
+const CSP_REPORT_ONLY_HEADER = "Content-Security-Policy-Report-Only";
+
+export type BuildCspOptions = {
+  reportOnly?: boolean;
+};
+
+export function buildCspHeader(opts: BuildCspOptions = {}): string {
+  const defaults = cspDefaults as CspDefaults;
+  const extraConnect = defaults.csp?.connectSrc ?? [];
+  const connectSrc = ["'self'", ...extraConnect];
+
+  const isProd = process.env.NODE_ENV === "production";
+  const scriptSrc = isProd ? ["'self'"] : ["'self'", "'unsafe-inline'"];
+
+  const directives: Record<string, string[]> = {
+    "default-src": ["'self'"],
+    "script-src": scriptSrc,
+    "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+    "font-src": ["'self'", "https://fonts.gstatic.com"],
+    "img-src": ["'self'", "data:", "blob:"],
+    "connect-src": connectSrc,
+    "frame-ancestors": ["'none'"],
+    "base-uri": ["'self'"],
+    "form-action": ["'self'"],
+  };
+
+  void opts;
+
+  return Object.entries(directives)
+    .map(([name, values]) => `${name} ${values.join(" ")}`)
+    .join("; ");
+}
+
+export function cspHeaderName(reportOnly = isReportOnly()): string {
+  return reportOnly ? CSP_REPORT_ONLY_HEADER : CSP_HEADER;
+}
+
+export function isReportOnly(): boolean {
+  return process.env.CSP_REPORT_ONLY === "true" || process.env.CSP_REPORT_ONLY === "1";
+}
+
+export function applyCspHeader<T extends NextResponse | Response>(response: T): T {
+  const reportOnly = isReportOnly();
+  response.headers.set(cspHeaderName(reportOnly), buildCspHeader({ reportOnly }));
+  return response;
+}

--- a/apps/web/lib/csrf.ts
+++ b/apps/web/lib/csrf.ts
@@ -1,0 +1,107 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export const CSRF_COOKIE = "csrf_token";
+export const CSRF_HEADER = "x-csrf-token";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+export type CsrfValidation =
+  | { ok: true }
+  | { ok: false; reason: "missing_cookie" | "missing_header" | "mismatch" };
+
+export function generateCsrfToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+export function ensureCsrfCookie(
+  response: NextResponse,
+  request?: NextRequest,
+): NextResponse {
+  const existing = request?.cookies.get(CSRF_COOKIE)?.value
+    ?? response.cookies.get(CSRF_COOKIE)?.value;
+  if (existing) return response;
+
+  const token = generateCsrfToken();
+  const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
+  // Append directly to avoid ResponseCookies re-serializing and clobbering
+  // other Set-Cookie headers (e.g. Auth0's session cookie) that were added
+  // via Headers.set / append rather than through the .cookies API.
+  response.headers.append(
+    "set-cookie",
+    `${CSRF_COOKIE}=${token}; Path=/; SameSite=Lax${secure}`,
+  );
+  return response;
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+export function validateCsrf(request: NextRequest | Request): CsrfValidation {
+  const method = request.method.toUpperCase();
+  if (SAFE_METHODS.has(method)) return { ok: true };
+
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  const cookieToken = parseCookieValue(cookieHeader, CSRF_COOKIE);
+  if (!cookieToken) return { ok: false, reason: "missing_cookie" };
+
+  const headerToken = request.headers.get(CSRF_HEADER);
+  if (!headerToken) return { ok: false, reason: "missing_header" };
+
+  return constantTimeEqual(cookieToken, headerToken)
+    ? { ok: true }
+    : { ok: false, reason: "mismatch" };
+}
+
+function parseCookieValue(cookieHeader: string, name: string): string | null {
+  if (!cookieHeader) return null;
+  const parts = cookieHeader.split(";");
+  for (const part of parts) {
+    const [rawKey, ...rawVal] = part.trim().split("=");
+    if (rawKey === name) {
+      const value = rawVal.join("=");
+      try {
+        return decodeURIComponent(value);
+      } catch {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+export function csrfFailureResponse(reason: string): Response {
+  return Response.json(
+    { error: "csrf_invalid", reason },
+    { status: 403 },
+  );
+}
+
+export function csrfFailureNextResponse(reason: string): NextResponse {
+  return NextResponse.json(
+    { error: "csrf_invalid", reason },
+    { status: 403 },
+  );
+}
+
+const CSRF_API_PREFIXES = ["/api/"];
+const CSRF_SKIP_PATHS = ["/api/webhooks/stripe", "/api/cron/", "/api/health", "/api/vitals"];
+
+export function shouldValidateCsrf(request: NextRequest): boolean {
+  const method = request.method.toUpperCase();
+  if (SAFE_METHODS.has(method)) return false;
+
+  const pathname = request.nextUrl.pathname;
+  if (!CSRF_API_PREFIXES.some((p) => pathname.startsWith(p))) return false;
+  if (CSRF_SKIP_PATHS.some((p) => pathname.startsWith(p))) return false;
+  return true;
+}

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+
+export type RateLimitResult = {
+  allowed: boolean;
+  remaining: number;
+  reset: number;
+  limit: number;
+};
+
+type Bucket = { count: number; resetAt: number };
+
+const buckets = new Map<string, Bucket>();
+
+function pruneExpired(now: number): void {
+  if (buckets.size < 1024) return;
+  for (const [key, bucket] of buckets) {
+    if (bucket.resetAt <= now) buckets.delete(key);
+  }
+}
+
+export function rateLimit(
+  key: string,
+  limit: number,
+  windowMs: number,
+  now: number = Date.now(),
+): RateLimitResult {
+  pruneExpired(now);
+  const existing = buckets.get(key);
+
+  if (!existing || existing.resetAt <= now) {
+    const fresh: Bucket = { count: 1, resetAt: now + windowMs };
+    buckets.set(key, fresh);
+    return {
+      allowed: true,
+      remaining: Math.max(limit - 1, 0),
+      reset: fresh.resetAt,
+      limit,
+    };
+  }
+
+  existing.count += 1;
+  const remaining = Math.max(limit - existing.count, 0);
+  return {
+    allowed: existing.count <= limit,
+    remaining,
+    reset: existing.resetAt,
+    limit,
+  };
+}
+
+export function getClientIp(headers: Headers): string {
+  const forwarded = headers.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return headers.get("x-real-ip") ?? "unknown";
+}
+
+function setRateLimitHeaders(
+  headers: Headers,
+  result: RateLimitResult,
+  now: number = Date.now(),
+): void {
+  headers.set("X-RateLimit-Limit", String(result.limit));
+  headers.set("X-RateLimit-Remaining", String(result.remaining));
+  headers.set("X-RateLimit-Reset", String(Math.ceil(result.reset / 1000)));
+  if (!result.allowed) {
+    const retryAfter = Math.max(Math.ceil((result.reset - now) / 1000), 0);
+    headers.set("Retry-After", String(retryAfter));
+  }
+}
+
+export function applyRateLimitHeaders<T extends Response | NextResponse>(
+  response: T,
+  result: RateLimitResult,
+): T {
+  setRateLimitHeaders(response.headers, result);
+  return response;
+}
+
+export function rateLimitResponse(result: RateLimitResult): Response {
+  const response = Response.json(
+    { error: "rate_limited", message: "Too many requests" },
+    { status: 429 },
+  );
+  setRateLimitHeaders(response.headers, result);
+  return response;
+}
+
+export function rateLimitNextResponse(result: RateLimitResult): NextResponse {
+  const response = NextResponse.json(
+    { error: "rate_limited", message: "Too many requests" },
+    { status: 429 },
+  );
+  setRateLimitHeaders(response.headers, result);
+  return response;
+}
+
+/** @internal — testing only */
+export function _resetRateLimitStore(): void {
+  buckets.clear();
+}

--- a/apps/web/lib/validate-request.ts
+++ b/apps/web/lib/validate-request.ts
@@ -1,0 +1,51 @@
+import type { z } from "zod";
+
+export type ValidationSuccess<T> = { ok: true; data: T };
+export type ValidationFailure = { ok: false; response: Response };
+export type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+/**
+ * Parse a JSON request body against a Zod schema. On failure returns a
+ * pre-built Response the caller can return directly, so route handlers stay
+ * short and the error shape stays consistent.
+ */
+export async function validateJson<T>(
+  request: Request,
+  schema: z.ZodType<T>,
+): Promise<ValidationResult<T>> {
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: Response.json(
+        {
+          error: "invalid_json",
+          message: "Request body is not valid JSON",
+        },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      response: Response.json(
+        {
+          error: "invalid_input",
+          issues: parsed.error.issues.map((issue) => ({
+            path: issue.path,
+            message: issue.message,
+            code: issue.code,
+          })),
+        },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { ok: true, data: parsed.data };
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -10,15 +10,36 @@ import {
   isVercelPreviewHost,
 } from "./lib/proxy-utils";
 import { applyCspHeader } from "./lib/csp";
+import {
+  applyRateLimitHeaders,
+  getClientIp,
+  rateLimit,
+  rateLimitNextResponse,
+} from "./lib/rate-limit";
+
+const AUTH_RATE_LIMIT = 10;
+const AUTH_RATE_WINDOW_MS = 60_000;
 
 export async function proxy(request: NextRequest): Promise<NextResponse> {
   const host = getHostFromRequestHeaders(request.headers);
   const auth0 = getAuth0ClientForHost(host);
-  const authResponse = await auth0.middleware(request);
 
   if (request.nextUrl.pathname.startsWith("/auth")) {
+    const ip = getClientIp(request.headers);
+    const result = rateLimit(
+      `auth:${ip}`,
+      AUTH_RATE_LIMIT,
+      AUTH_RATE_WINDOW_MS,
+    );
+    if (!result.allowed) {
+      return applyCspHeader(rateLimitNextResponse(result));
+    }
+    const authResponse = await auth0.middleware(request);
+    applyRateLimitHeaders(authResponse, result);
     return applyCspHeader(authResponse);
   }
+
+  const authResponse = await auth0.middleware(request);
 
   const withAuth = (inner: NextResponse) =>
     applyCspHeader(mergeAuthMiddlewareResponse(authResponse, inner));

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -9,6 +9,7 @@ import {
   getRouteForSubdomain,
   isVercelPreviewHost,
 } from "./lib/proxy-utils";
+import { applyCspHeader } from "./lib/csp";
 
 export async function proxy(request: NextRequest): Promise<NextResponse> {
   const host = getHostFromRequestHeaders(request.headers);
@@ -16,11 +17,11 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   const authResponse = await auth0.middleware(request);
 
   if (request.nextUrl.pathname.startsWith("/auth")) {
-    return authResponse;
+    return applyCspHeader(authResponse);
   }
 
   const withAuth = (inner: NextResponse) =>
-    mergeAuthMiddlewareResponse(authResponse, inner);
+    applyCspHeader(mergeAuthMiddlewareResponse(authResponse, inner));
 
   const hostHeader = request.headers.get("host") ?? "";
   const isPreview = isVercelPreviewHost(hostHeader);
@@ -63,9 +64,11 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   const routePath = getRouteForSubdomain(subdomain);
 
   if (!routePath) {
-    return mergeAuthMiddlewareResponse(
-      authResponse,
-      NextResponse.redirect(new URL("https://auth.lastrev.com")),
+    return applyCspHeader(
+      mergeAuthMiddlewareResponse(
+        authResponse,
+        NextResponse.redirect(new URL("https://auth.lastrev.com")),
+      ),
     );
   }
 

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -16,11 +16,24 @@ import {
   rateLimit,
   rateLimitNextResponse,
 } from "./lib/rate-limit";
+import {
+  csrfFailureNextResponse,
+  ensureCsrfCookie,
+  shouldValidateCsrf,
+  validateCsrf,
+} from "./lib/csrf";
 
 const AUTH_RATE_LIMIT = 10;
 const AUTH_RATE_WINDOW_MS = 60_000;
 
 export async function proxy(request: NextRequest): Promise<NextResponse> {
+  if (shouldValidateCsrf(request)) {
+    const csrf = validateCsrf(request);
+    if (!csrf.ok) {
+      return applyCspHeader(csrfFailureNextResponse(csrf.reason));
+    }
+  }
+
   const host = getHostFromRequestHeaders(request.headers);
   const auth0 = getAuth0ClientForHost(host);
 
@@ -42,7 +55,12 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   const authResponse = await auth0.middleware(request);
 
   const withAuth = (inner: NextResponse) =>
-    applyCspHeader(mergeAuthMiddlewareResponse(authResponse, inner));
+    applyCspHeader(
+      ensureCsrfCookie(
+        mergeAuthMiddlewareResponse(authResponse, inner),
+        request,
+      ),
+    );
 
   const hostHeader = request.headers.get("host") ?? "";
   const isPreview = isVercelPreviewHost(hostHeader);

--- a/docs/ops/api-validation.md
+++ b/docs/ops/api-validation.md
@@ -1,0 +1,78 @@
+# API input validation
+
+All API routes that accept JSON input should validate the body against a
+Zod schema via `validateJson` in `apps/web/lib/validate-request.ts`.
+
+## Pattern
+
+```ts
+import { z } from "zod";
+import { validateJson } from "@/lib/validate-request";
+
+const bodySchema = z.object({
+  priceId: z.string().min(1),
+});
+
+export async function POST(request: Request): Promise<Response> {
+  const parsed = await validateJson(request, bodySchema);
+  if (!parsed.ok) return parsed.response;
+
+  const { priceId } = parsed.data;
+  // ... handler logic with typed data ...
+}
+```
+
+`validateJson` returns a discriminated union:
+
+- `{ ok: true, data: T }` — `data` is typed to the schema's inferred type.
+- `{ ok: false, response: Response }` — a pre-built `Response` the handler
+  returns directly.
+
+## Error response shape
+
+Two shapes, both HTTP 400:
+
+**Malformed JSON**
+
+```json
+{
+  "error": "invalid_json",
+  "message": "Request body is not valid JSON"
+}
+```
+
+**Schema failure**
+
+```json
+{
+  "error": "invalid_input",
+  "issues": [
+    { "path": ["priceId"], "message": "String must contain at least 1 character(s)", "code": "too_small" }
+  ]
+}
+```
+
+The `issues` array is Zod's `ZodIssue[]` flattened to the three fields
+clients need (`path`, `message`, `code`) so we can evolve internals without
+breaking consumers.
+
+## Webhook routes
+
+The Stripe webhook (`/api/webhooks/stripe`) receives a raw `Buffer` rather
+than JSON — signature verification requires the untouched bytes. For those
+routes, validate the **header envelope** with Zod instead:
+
+```ts
+const headerSchema = z.object({
+  "stripe-signature": z.string().min(1),
+});
+```
+
+Any new JSON fields added to webhook routes should use `validateJson` on the
+JSON sub-object.
+
+## When to skip
+
+`validateJson` is for route handlers receiving untrusted external JSON.
+Server components, server actions already typed by framework contracts, and
+internal helpers do not need it.

--- a/packages/auth/src/auth0-factory.ts
+++ b/packages/auth/src/auth0-factory.ts
@@ -1,6 +1,8 @@
 import { Auth0Client } from "@auth0/nextjs-auth0/server";
 import { NextResponse } from "next/server";
 import { log } from "@repo/logger";
+import { logAuditEvent } from "@repo/db/audit";
+import { createServiceRoleClient } from "@repo/db/service-role";
 import { maybeSelfEnrollAfterLogin, appSlugFromReturnTo } from "./self-enroll";
 
 const ALLOWED_RETURN_HOSTS = [
@@ -104,6 +106,10 @@ export function getAuth0ClientForHost(host: string): Auth0Client {
         "http://localhost:3000";
 
       if (error) {
+        await logAuditEvent(createServiceRoleClient(), {
+          action: "auth.login.failed",
+          metadata: { reason: error.message, returnTo: ctx.returnTo ?? null },
+        });
         const u = new URL("/login", appBaseUrl);
         u.searchParams.set("error", error.message);
         // Preserve the redirect param so the user can retry without losing their destination
@@ -116,6 +122,10 @@ export function getAuth0ClientForHost(host: string): Auth0Client {
 
       // Handle expired/invalid session: redirect to login with session_expired error
       if (!session?.user?.sub) {
+        await logAuditEvent(createServiceRoleClient(), {
+          action: "auth.login.failed",
+          metadata: { reason: "session_expired", returnTo: ctx.returnTo ?? null },
+        });
         const u = new URL("/login", appBaseUrl);
         u.searchParams.set("error", "session_expired");
         const slug = appSlugFromReturnTo(ctx.returnTo);
@@ -134,6 +144,12 @@ export function getAuth0ClientForHost(host: string): Auth0Client {
           returnTo: ctx.returnTo,
         });
       }
+
+      await logAuditEvent(createServiceRoleClient(), {
+        userId: session.user.sub,
+        action: "auth.login.succeeded",
+        metadata: { returnTo: ctx.returnTo ?? null },
+      });
 
       // Validate returnTo to prevent open-redirect
       const rawTarget = ctx.returnTo || "/my-apps";

--- a/packages/billing/src/webhook-handler.test.ts
+++ b/packages/billing/src/webhook-handler.test.ts
@@ -22,6 +22,7 @@ const mockMaybeSingle = vi.fn();
 const mockEq = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
 const mockSelect = vi.fn(() => ({ eq: mockEq }));
 const mockInsert = vi.fn();
+const mockAuditInsert = vi.fn().mockResolvedValue({ error: null });
 const mockUpdate = vi.fn(() => ({ eq: vi.fn() }));
 const mockFrom = vi.fn((table: string) => {
   if (table === "processed_webhook_events") {
@@ -29,6 +30,9 @@ const mockFrom = vi.fn((table: string) => {
       select: mockSelect,
       insert: mockInsert,
     };
+  }
+  if (table === "audit_log") {
+    return { insert: mockAuditInsert };
   }
   return { update: mockUpdate };
 });
@@ -174,6 +178,33 @@ describe("handleStripeWebhook", () => {
     await handleStripeWebhook("body", "sig");
 
     expect(mockInsert).toHaveBeenCalledWith({ event_id: "evt_new" });
+  });
+
+  it("writes an audit_log entry for subscription events", async () => {
+    const subscription = {
+      id: "sub_audit",
+      customer: "cus_audit",
+      status: "active",
+    };
+    mockConstructEvent.mockReturnValue({
+      id: "evt_audit",
+      type: "customer.subscription.created",
+      data: { object: subscription },
+    });
+
+    await handleStripeWebhook("body", "sig");
+
+    expect(mockAuditInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "subscription.created",
+        resource: "sub_audit",
+        metadata: expect.objectContaining({
+          eventId: "evt_audit",
+          customerId: "cus_audit",
+          status: "active",
+        }),
+      }),
+    );
   });
 
   it("does not throw when insert into processed_webhook_events fails (fail open)", async () => {

--- a/packages/billing/src/webhook-handler.ts
+++ b/packages/billing/src/webhook-handler.ts
@@ -2,9 +2,16 @@ import type Stripe from "stripe";
 import { getStripe } from "./stripe-client";
 import { upsertSubscription } from "./subscriptions";
 import { createServiceRoleClient } from "@repo/db/service-role";
+import { logAuditEvent } from "@repo/db/audit";
 import type { Database } from "@repo/db/types";
 import { log } from "@repo/logger";
 import type { WebhookEventType } from "./types";
+
+const AUDIT_ACTIONS: Record<string, string> = {
+  "customer.subscription.created": "subscription.created",
+  "customer.subscription.updated": "subscription.updated",
+  "customer.subscription.deleted": "subscription.deleted",
+};
 
 const HANDLED_EVENTS: Set<string> = new Set<WebhookEventType>([
   "customer.subscription.created",
@@ -67,6 +74,22 @@ export async function handleStripeWebhook(
       err,
       eventId: event.id,
       eventType: event.type,
+    });
+  }
+
+  const auditAction = AUDIT_ACTIONS[event.type];
+  if (auditAction) {
+    await logAuditEvent(db, {
+      action: auditAction,
+      resource: subscription.id,
+      metadata: {
+        eventId: event.id,
+        customerId:
+          typeof subscription.customer === "string"
+            ? subscription.customer
+            : subscription.customer?.id,
+        status: subscription.status,
+      },
     });
   }
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,7 +12,8 @@
     "./client": "./src/client.ts",
     "./middleware": "./src/middleware.ts",
     "./types": "./src/types.ts",
-    "./service-role": "./src/service-role.ts"
+    "./service-role": "./src/service-role.ts",
+    "./audit": "./src/audit.ts"
   },
   "dependencies": {
     "@supabase/ssr": "^0.6",

--- a/packages/db/src/__tests__/audit.test.ts
+++ b/packages/db/src/__tests__/audit.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../types";
+import { logAuditEvent } from "../audit";
+
+function mockClient(insertResult: { error: unknown } = { error: null }) {
+  const insert = vi.fn().mockResolvedValue(insertResult);
+  const from = vi.fn().mockReturnValue({ insert });
+  return {
+    client: { from } as unknown as SupabaseClient<Database>,
+    insert,
+    from,
+  };
+}
+
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+beforeEach(() => {
+  consoleErrorSpy.mockClear();
+});
+
+describe("logAuditEvent", () => {
+  it("inserts the expected row shape", async () => {
+    const { client, insert, from } = mockClient();
+
+    await logAuditEvent(client, {
+      userId: "user-1",
+      action: "subscription.created",
+      resource: "sub_abc",
+      metadata: { priceId: "price_pro_monthly" },
+      ipAddress: "1.2.3.4",
+      userAgent: "curl/8",
+    });
+
+    expect(from).toHaveBeenCalledWith("audit_log");
+    expect(insert).toHaveBeenCalledWith({
+      user_id: "user-1",
+      action: "subscription.created",
+      resource: "sub_abc",
+      metadata: { priceId: "price_pro_monthly" },
+      ip_address: "1.2.3.4",
+      user_agent: "curl/8",
+    });
+  });
+
+  it("defaults optional fields to null / empty metadata", async () => {
+    const { client, insert } = mockClient();
+
+    await logAuditEvent(client, { action: "checkout.session.created" });
+
+    expect(insert).toHaveBeenCalledWith({
+      user_id: null,
+      action: "checkout.session.created",
+      resource: null,
+      metadata: {},
+      ip_address: null,
+      user_agent: null,
+    });
+  });
+
+  it("swallows database errors and logs them", async () => {
+    const { client } = mockClient({ error: { message: "RLS denied" } });
+
+    await expect(
+      logAuditEvent(client, { action: "subscription.updated" }),
+    ).resolves.toBeUndefined();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "logAuditEvent failed",
+      expect.objectContaining({ action: "subscription.updated" }),
+    );
+  });
+
+  it("swallows thrown errors and logs them", async () => {
+    const client = {
+      from: vi.fn(() => {
+        throw new Error("network down");
+      }),
+    } as unknown as SupabaseClient<Database>;
+
+    await expect(
+      logAuditEvent(client, { action: "login" }),
+    ).resolves.toBeUndefined();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "logAuditEvent threw",
+      expect.objectContaining({ action: "login" }),
+    );
+  });
+});

--- a/packages/db/src/audit.ts
+++ b/packages/db/src/audit.ts
@@ -1,0 +1,44 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "./types";
+
+export type AuditEvent = {
+  userId?: string | null;
+  action: string;
+  resource?: string | null;
+  metadata?: Record<string, unknown>;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+};
+
+/**
+ * Write an audit-log row. Failures are swallowed and logged to the console
+ * so audit instrumentation never takes down the caller's flow. Requires
+ * a service-role client because the `audit_log` table has no insert policy.
+ */
+export async function logAuditEvent(
+  client: SupabaseClient<Database>,
+  event: AuditEvent,
+): Promise<void> {
+  try {
+    const row: Database["public"]["Tables"]["audit_log"]["Insert"] = {
+      user_id: event.userId ?? null,
+      action: event.action,
+      resource: event.resource ?? null,
+      metadata: event.metadata ?? {},
+      ip_address: event.ipAddress ?? null,
+      user_agent: event.userAgent ?? null,
+    };
+    const { error } = await client.from("audit_log").insert(row);
+    if (error) {
+      console.error("logAuditEvent failed", {
+        action: event.action,
+        error: error.message,
+      });
+    }
+  } catch (err) {
+    console.error("logAuditEvent threw", {
+      action: event.action,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,5 @@
 export { createClient as createServerClient } from "./server";
 export { createMiddlewareClient } from "./middleware";
 export { getAppPermission, getUserSubscription, upsertPermission } from "./queries";
-export type { Database, AppPermission, Permission, SubscriptionRow } from "./types";
+export { logAuditEvent, type AuditEvent } from "./audit";
+export type { Database, AppPermission, Permission, SubscriptionRow, AuditLogRow } from "./types";

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -35,6 +35,17 @@ export type ProcessedWebhookEvent = {
   processed_at: string;
 };
 
+export type AuditLogRow = {
+  id: string;
+  user_id: string | null;
+  action: string;
+  resource: string | null;
+  metadata: Record<string, unknown>;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: string;
+};
+
 export interface Database {
   public: {
     Tables: {
@@ -56,6 +67,13 @@ export interface Database {
         Insert: Pick<ProcessedWebhookEvent, "event_id"> &
           Partial<Pick<ProcessedWebhookEvent, "processed_at">>;
         Update: Partial<ProcessedWebhookEvent>;
+        Relationships: [];
+      };
+      audit_log: {
+        Row: AuditLogRow;
+        Insert: Pick<AuditLogRow, "action"> &
+          Partial<Omit<AuditLogRow, "id" | "action" | "created_at">>;
+        Update: Partial<Omit<AuditLogRow, "id" | "created_at">>;
         Relationships: [];
       };
     };

--- a/supabase/migrations/20260421_audit_log.down.sql
+++ b/supabase/migrations/20260421_audit_log.down.sql
@@ -1,0 +1,5 @@
+drop policy if exists "Auth admins read all audit log" on public.audit_log;
+drop policy if exists "Users read own audit log" on public.audit_log;
+drop index if exists public.idx_audit_log_action_created;
+drop index if exists public.idx_audit_log_user_created;
+drop table if exists public.audit_log;

--- a/supabase/migrations/20260421_audit_log.sql
+++ b/supabase/migrations/20260421_audit_log.sql
@@ -1,0 +1,38 @@
+-- Create audit_log table for security-relevant events (auth, billing, admin actions).
+create table if not exists public.audit_log (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references auth.users(id) on delete set null,
+  action text not null,
+  resource text,
+  metadata jsonb default '{}'::jsonb not null,
+  ip_address inet,
+  user_agent text,
+  created_at timestamptz default now() not null
+);
+
+alter table public.audit_log enable row level security;
+
+-- Users can read their own audit entries.
+create policy "Users read own audit log"
+  on public.audit_log for select
+  using (auth.uid() = user_id);
+
+-- Auth app admins can read all audit entries.
+create policy "Auth admins read all audit log"
+  on public.audit_log for select
+  using (
+    exists (
+      select 1 from public.app_permissions
+      where user_id = auth.uid()
+      and app_slug = 'auth'
+      and permission = 'admin'
+    )
+  );
+
+-- No insert/update/delete policies: all writes go through the service-role client.
+
+create index if not exists idx_audit_log_user_created
+  on public.audit_log(user_id, created_at desc);
+
+create index if not exists idx_audit_log_action_created
+  on public.audit_log(action, created_at desc);

--- a/turbo.json
+++ b/turbo.json
@@ -36,7 +36,8 @@
     "SENTRY_ORG",
     "SENTRY_PROJECT",
     "VERCEL_GIT_COMMIT_SHA",
-    "VERCEL_DEPLOYMENT_ID"
+    "VERCEL_DEPLOYMENT_ID",
+    "CSP_REPORT_ONLY"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
Closes #160
Closes #161
Closes #162
Closes #163
Closes #164

## Summary

Batch implementation of 5 issues:
- **#160**: Enforce CSP headers in proxy.ts
- **#161**: Add rate limiting on auth and webhook routes
- **#162**: Add audit log table and logging middleware
- **#163**: Add Zod input validation on API routes
- **#164**: Add CSRF protection for state-changing requests

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Details | 1315 passed |

## Code Review

All 5 issues implemented; one wiring gap (audit log not called from auth handlers) was fixed during review.

- **WARNING** [FIXED] `packages/auth/src/auth0-factory.ts`: Issue #162 spec required logAuditEvent to be called from auth handlers, but only billing handlers (webhook + checkout) were wired. The auth0-factory onCallback handler updated logger calls but never emitted audit events for login success/failure. Fixed by adding logAuditEvent calls for auth.login.succeeded and auth.login.failed in onCallback.
- **INFO** [OPEN] `apps/web/lib/csp.ts`: BuildCspOptions.reportOnly parameter is accepted but ignored (void opts;). Functionally correct because report-only only changes the header name, not the directives, but the parameter is dead and could be removed for clarity.
- **INFO** [OPEN] `apps/web/lib/rate-limit.ts`: Rate limiter uses an in-memory Map<string, Bucket>. On a multi-instance / serverless deployment each instance counts separately, so effective limits are N x configured value where N is the instance count. Acceptable for v1 but should be migrated to a shared store (Upstash/Redis) before relying on the published per-IP figures.
- **INFO** [OPEN] `apps/web/lib/csrf.ts`: CSRF cookie omits HttpOnly intentionally (the client must read it to copy into the x-csrf-token header). This is the correct double-submit pattern but is worth noting: an XSS would let an attacker bypass CSRF. The cookie does carry SameSite=Lax which mitigates classic cross-site form CSRF, and Secure is added in production.
- **INFO** [OPEN] `apps/web/app/api/vitals/route.ts`: apps/web/app/api/vitals/route.ts validates input with Zod inline rather than via the shared validateJson helper documented in docs/ops/api-validation.md. Functionally equivalent; the route returns body-less 400/204 to match the navigator.sendBeacon contract, which is reasonable but slightly inconsistent with the documented pattern.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Batch mode · Full logs in `.alpha-loop/sessions/`*