### PR TITLE
feat: batch implementation (#265, #266, #267, #268, #269)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`lr-apps` is a Turborepo monorepo that hosts ~27 small apps under one Next.js App Router deployment (`apps/web`). Subdomain-based routing is implemented in `apps/web/proxy.ts`: `<slug>.lastrev.com` is rewritten to `/apps/<routeGroup>/...`, and `auth.lastrev.com` is the central auth hub. The proxy merges Auth0 v4 middleware cookies/headers with the rewrite response via `mergeAuthMiddlewareResponse`, then layers CSP, rate limiting, and CSRF on top. App metadata (slug, subdomain, route group, tier, gating) lives in `apps/web/lib/app-registry.ts` and is the single source of truth consumed by both the proxy and per-app layouts.
+`lr-apps` is a Turborepo monorepo that hosts ~28 small apps under one Next.js App Router deployment (`apps/web`). Subdomain-based routing is implemented in `apps/web/proxy.ts`: `<slug>.lastrev.com` is rewritten to `/apps/<routeGroup>/...`, and `auth.lastrev.com` is the central auth hub. The proxy merges Auth0 v4 middleware cookies/headers with the rewrite response via `mergeAuthMiddlewareResponse`, then layers CSP, rate limiting, and CSRF on top. App metadata (slug, subdomain, route group, tier, gating) lives in `apps/web/lib/app-registry.ts` and is the single source of truth consumed by both the proxy and per-app layouts.
 
 ## Tech Stack
 
@@ -29,7 +29,7 @@ apps/web/
       layout.tsx
       (dashboard)/account, (dashboard)/my-apps
       (forms)/login, (forms)/signup, (forms)/unauthorized
-    apps/<slug>/                 # 27 apps (accounts, command-center, sentiment, ...)
+    apps/<slug>/                 # 28 apps (accounts, client-health, command-center, sentiment, ...)
     api/                         # checkout, cron, health, vitals, webhooks
     checkout/, pricing/
   lib/                           # Shared web-app helpers (see lib-listing below)

--- a/apps/web/app/apps/client-health/__tests__/page.test.tsx
+++ b/apps/web/app/apps/client-health/__tests__/page.test.tsx
@@ -1,0 +1,11 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { renderWithProviders, screen } from "@repo/test-utils";
+import ClientHealthPage from "../page";
+
+describe("ClientHealthPage", () => {
+  it("renders the page heading", () => {
+    renderWithProviders(<ClientHealthPage />);
+    expect(screen.getByRole("heading", { name: "Client Health" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/apps/client-health/layout.tsx
+++ b/apps/web/app/apps/client-health/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+import { requireAppLayoutAccess } from "@/lib/require-app-layout-access";
+
+export const metadata = {
+  title: "Client Health",
+};
+
+export default async function ClientHealthLayout({ children }: { children: ReactNode }) {
+  await requireAppLayoutAccess("client-health");
+  return <main className="min-h-screen max-w-6xl mx-auto px-4 py-6">{children}</main>;
+}

--- a/apps/web/app/apps/client-health/page.tsx
+++ b/apps/web/app/apps/client-health/page.tsx
@@ -1,0 +1,7 @@
+export default function ClientHealthPage() {
+  return (
+    <div>
+      <h1 className="font-heading text-2xl font-bold">Client Health</h1>
+    </div>
+  );
+}

--- a/apps/web/lib/__tests__/app-registry.test.ts
+++ b/apps/web/lib/__tests__/app-registry.test.ts
@@ -100,8 +100,8 @@ describe("app-registry", () => {
   });
 
   describe("registry integrity", () => {
-    it("registers at least 27 apps", () => {
-      expect(getAllApps().length).toBeGreaterThanOrEqual(27);
+    it("registers at least 28 apps", () => {
+      expect(getAllApps().length).toBeGreaterThanOrEqual(28);
     });
 
     it("no duplicate slugs", () => {

--- a/apps/web/lib/app-registry.ts
+++ b/apps/web/lib/app-registry.ts
@@ -80,6 +80,7 @@ const apps: AppConfig[] = [
   { slug: "area-52", name: "Area 52", subdomain: "area-52", routeGroup: "apps/area-52", auth: true, permission: "view", template: "minimal", tier: "free", features: {} },
   { slug: "brommie-quake", name: "Brommie Quake", subdomain: "brommie", routeGroup: "apps/brommie-quake", auth: true, permission: "view", template: "minimal", tier: "free", features: {} },
   { slug: "age-of-apes", name: "Age of Apes", subdomain: "apes", routeGroup: "apps/age-of-apes", auth: true, permission: "view", template: "minimal", tier: "free", features: {} },
+  { slug: "client-health", name: "Client Health", subdomain: "client-health", routeGroup: "apps/client-health", auth: true, permission: "view", template: "full", tier: "free", features: {} },
 ];
 
 const subdomainIndex = new Map(apps.map((app) => [app.subdomain, app]));

--- a/supabase/migrations/20260429a_clients.down.sql
+++ b/supabase/migrations/20260429a_clients.down.sql
@@ -1,0 +1,8 @@
+drop trigger if exists set_clients_updated_at on public.clients;
+drop policy if exists "Users delete own clients" on public.clients;
+drop policy if exists "Users update own clients" on public.clients;
+drop policy if exists "Users insert own clients" on public.clients;
+drop policy if exists "Users read own clients" on public.clients;
+drop index if exists public.idx_clients_user_status;
+drop table if exists public.clients;
+drop function if exists public.set_updated_at();

--- a/supabase/migrations/20260429a_clients.sql
+++ b/supabase/migrations/20260429a_clients.sql
@@ -1,0 +1,63 @@
+-- Create clients table for the client-health mini-app.
+-- Side-effect: partially unblocks the accounts app, which queries a
+-- previously-missing public.clients table. See
+-- docs/guides/promote-client-health-to-app.md for the full plan.
+
+-- Standard updatedAt trigger function. Defined here as the first user;
+-- subsequent migrations reuse it via:
+--   create trigger ... before update on <table>
+--     for each row execute function public.set_updated_at();
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new."updatedAt" = now();
+  return new;
+end;
+$$;
+
+create table if not exists public.clients (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+
+  name text not null check (length(trim(name)) > 0),
+  industry text,
+  status text not null default 'active'
+    check (status in ('active', 'paused', 'churned', 'prospect')),
+
+  "contractStatus" text check ("contractStatus" in ('active', 'expiring-soon', 'expired', 'none')),
+  "contractEndDate" date,
+
+  "primaryContactName" text,
+  "primaryContactEmail" text,
+  notes text,
+
+  "createdAt" timestamptz not null default now(),
+  "updatedAt" timestamptz not null default now()
+);
+
+alter table public.clients enable row level security;
+
+create policy "Users read own clients"
+  on public.clients for select
+  using (auth.uid() = user_id);
+
+create policy "Users insert own clients"
+  on public.clients for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users update own clients"
+  on public.clients for update
+  using (auth.uid() = user_id);
+
+create policy "Users delete own clients"
+  on public.clients for delete
+  using (auth.uid() = user_id);
+
+create index if not exists idx_clients_user_status
+  on public.clients(user_id, status);
+
+create trigger set_clients_updated_at
+  before update on public.clients
+  for each row execute function public.set_updated_at();

--- a/supabase/migrations/20260429b_client_sites.down.sql
+++ b/supabase/migrations/20260429b_client_sites.down.sql
@@ -1,0 +1,7 @@
+drop trigger if exists set_client_sites_updated_at on public.client_sites;
+drop policy if exists "Users delete own client sites" on public.client_sites;
+drop policy if exists "Users update own client sites" on public.client_sites;
+drop policy if exists "Users insert own client sites" on public.client_sites;
+drop policy if exists "Users read own client sites" on public.client_sites;
+drop index if exists public.idx_client_sites_user_client;
+drop table if exists public.client_sites;

--- a/supabase/migrations/20260429b_client_sites.sql
+++ b/supabase/migrations/20260429b_client_sites.sql
@@ -1,0 +1,44 @@
+-- Create client_sites table mapping clients to monitored URLs.
+-- URLs are joined to status-pulse's `sites` table by URL match.
+create table if not exists public.client_sites (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  "clientId" uuid not null references public.clients(id) on delete cascade,
+
+  label text not null,
+  url text not null,
+
+  "isPrimary" boolean not null default false,
+  "openTicketCount" integer not null default 0 check ("openTicketCount" >= 0),
+  "ticketsLastUpdated" timestamptz,
+
+  "createdAt" timestamptz not null default now(),
+  "updatedAt" timestamptz not null default now(),
+
+  unique (user_id, "clientId", url)
+);
+
+alter table public.client_sites enable row level security;
+
+create policy "Users read own client sites"
+  on public.client_sites for select
+  using (auth.uid() = user_id);
+
+create policy "Users insert own client sites"
+  on public.client_sites for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users update own client sites"
+  on public.client_sites for update
+  using (auth.uid() = user_id);
+
+create policy "Users delete own client sites"
+  on public.client_sites for delete
+  using (auth.uid() = user_id);
+
+create index if not exists idx_client_sites_user_client
+  on public.client_sites(user_id, "clientId");
+
+create trigger set_client_sites_updated_at
+  before update on public.client_sites
+  for each row execute function public.set_updated_at();

--- a/supabase/migrations/20260429c_site_metadata.down.sql
+++ b/supabase/migrations/20260429c_site_metadata.down.sql
@@ -1,0 +1,3 @@
+drop trigger if exists set_site_metadata_updated_at on public.site_metadata;
+drop policy if exists "Authenticated read site metadata" on public.site_metadata;
+drop table if exists public.site_metadata;

--- a/supabase/migrations/20260429c_site_metadata.sql
+++ b/supabase/migrations/20260429c_site_metadata.sql
@@ -1,0 +1,32 @@
+-- site_metadata is keyed by URL (not user_id) because SSL/cert data is
+-- intrinsically site-level. Multiple users may monitor the same URL;
+-- storing a single row per URL avoids duplicate TLS handshakes from
+-- the SSL cron. Writes go through the service-role client
+-- (@repo/db/service-role) and bypass RLS; reads are open to any
+-- authenticated user.
+create table if not exists public.site_metadata (
+  url text primary key,
+
+  "sslExpiry" timestamptz,
+  "sslIssuer" text,
+  "sslLastChecked" timestamptz,
+  "sslLastError" text,
+
+  notes text,
+
+  "createdAt" timestamptz not null default now(),
+  "updatedAt" timestamptz not null default now()
+);
+
+alter table public.site_metadata enable row level security;
+
+create policy "Authenticated read site metadata"
+  on public.site_metadata for select
+  using (auth.role() = 'authenticated');
+
+-- No insert/update/delete policies: writes go through the service-role
+-- client (which bypasses RLS).
+
+create trigger set_site_metadata_updated_at
+  before update on public.site_metadata
+  for each row execute function public.set_updated_at();

--- a/supabase/migrations/20260429d_client_health_settings.down.sql
+++ b/supabase/migrations/20260429d_client_health_settings.down.sql
@@ -1,0 +1,5 @@
+drop trigger if exists set_client_health_settings_updated_at on public.client_health_settings;
+drop policy if exists "Users update own settings" on public.client_health_settings;
+drop policy if exists "Users insert own settings" on public.client_health_settings;
+drop policy if exists "Users read own settings" on public.client_health_settings;
+drop table if exists public.client_health_settings;

--- a/supabase/migrations/20260429d_client_health_settings.sql
+++ b/supabase/migrations/20260429d_client_health_settings.sql
@@ -1,0 +1,31 @@
+-- Per-user alert preferences for the client-health app.
+-- One row per user_id (PK on user_id; no separate id column).
+create table if not exists public.client_health_settings (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+
+  "emailEnabled" boolean not null default true,
+  "alertEmail" text,
+  "sslWarnDays" integer not null default 30 check ("sslWarnDays" between 1 and 365),
+  "healthDropThreshold" integer not null default 20 check ("healthDropThreshold" between 1 and 100),
+
+  "createdAt" timestamptz not null default now(),
+  "updatedAt" timestamptz not null default now()
+);
+
+alter table public.client_health_settings enable row level security;
+
+create policy "Users read own settings"
+  on public.client_health_settings for select
+  using (auth.uid() = user_id);
+
+create policy "Users insert own settings"
+  on public.client_health_settings for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users update own settings"
+  on public.client_health_settings for update
+  using (auth.uid() = user_id);
+
+create trigger set_client_health_settings_updated_at
+  before update on public.client_health_settings
+  for each row execute function public.set_updated_at();


### PR DESCRIPTION
Closes #265
Closes #266
Closes #267
Closes #268
Closes #269

## Summary

Batch implementation of 5 issues:
- **#265**: Scaffold client-health mini-app via pnpm create-app
- **#266**: Migration: clients table (paired up/down)
- **#267**: Migration: client_sites table (paired up/down)
- **#268**: Migration: site_metadata table (paired up/down)
- **#269**: Migration: client_health_settings table (paired up/down)

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Details | 1363 passed |

## Code Review

All 5 issues fully implemented; new files lint-clean, app-registry tests pass, migration pairs valid.

- **INFO** [OPEN] `supabase/migrations/20260429a_clients.down.sql`: clients.down.sql drops public.set_updated_at(), which is reused by client_sites/site_metadata/client_health_settings. Reverse-order rollback is safe (dependent triggers drop first); a partial rollback would fail the function drop rather than corrupt state. Acceptable but worth noting.
- **INFO** [OPEN] `supabase/migrations/20260429a_clients.sql`: Issue plan referenced 'same pattern as ideas' for the updatedAt trigger, but no ideas migration exists in the repo. The clients migration introduces public.set_updated_at() as the first user (with an explanatory comment); subsequent migrations reuse it. Matches intent.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Batch mode · Full logs in `.alpha-loop/sessions/`*