### PR TITLE
fix: redirect to absolute auth-hub URL on app subdomains

### DIFF
--- a/apps/web/app/(auth)/(forms)/unauthorized/actions.ts
+++ b/apps/web/app/(auth)/(forms)/unauthorized/actions.ts
@@ -6,24 +6,31 @@ import {
   getAuth0ClientForHost,
   getHostFromRequestHeaders,
 } from "@repo/auth/auth0-factory";
+import { authHubUrl } from "@repo/auth/cluster-host";
 import { selfEnrollUserIfAllowed } from "@repo/auth/self-enroll";
 import { getAppBySlug } from "@/lib/app-registry";
 
 export async function requestAppAccess(formData: FormData) {
   const slug = String(formData.get("app") ?? "").trim();
-  if (!slug) redirect("/my-apps");
-
   const h = await headers();
-  const auth0 = getAuth0ClientForHost(getHostFromRequestHeaders(h));
+  const host = getHostFromRequestHeaders(h);
+  if (!slug) redirect(authHubUrl(host, "/my-apps"));
+
+  const auth0 = getAuth0ClientForHost(host);
   const session = await auth0.getSession();
 
   if (!session?.user?.sub) {
-    redirect(`/login?redirect=${encodeURIComponent(slug)}`);
+    redirect(authHubUrl(host, `/login?redirect=${encodeURIComponent(slug)}`));
   }
 
   const ok = await selfEnrollUserIfAllowed(session.user.sub, slug);
   if (!ok) {
-    redirect(`/unauthorized?app=${encodeURIComponent(slug)}&error=closed`);
+    redirect(
+      authHubUrl(
+        host,
+        `/unauthorized?app=${encodeURIComponent(slug)}&error=closed`,
+      ),
+    );
   }
 
   const app = getAppBySlug(slug);

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -11,6 +11,7 @@
     "./server": "./src/require-access.ts",
     "./client": "./src/auth-provider.tsx",
     "./auth0-factory": "./src/auth0-factory.ts",
+    "./cluster-host": "./src/cluster-host.ts",
     "./merge-auth-middleware": "./src/merge-auth-middleware.ts",
     "./self-enroll": "./src/self-enroll.ts"
   },

--- a/packages/auth/src/__tests__/cluster-host.test.ts
+++ b/packages/auth/src/__tests__/cluster-host.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  authHubOriginForHost,
+  authHubUrl,
+  isAuthHubOrigin,
+} from "../cluster-host";
+
+describe("authHubOriginForHost", () => {
+  it("returns auth.apps.lastrev.com on the apps cluster", () => {
+    expect(authHubOriginForHost("generations.apps.lastrev.com")).toBe(
+      "https://auth.apps.lastrev.com",
+    );
+    expect(authHubOriginForHost("auth.apps.lastrev.com")).toBe(
+      "https://auth.apps.lastrev.com",
+    );
+    expect(authHubOriginForHost("apps.lastrev.com")).toBe(
+      "https://auth.apps.lastrev.com",
+    );
+  });
+
+  it("returns auth.lastrev.com on the legacy cluster", () => {
+    expect(authHubOriginForHost("sentiment.lastrev.com")).toBe(
+      "https://auth.lastrev.com",
+    );
+    expect(authHubOriginForHost("auth.lastrev.com")).toBe(
+      "https://auth.lastrev.com",
+    );
+  });
+
+  it("preserves port for local apps and legacy clusters", () => {
+    expect(authHubOriginForHost("generations.apps.lastrev.localhost:3000")).toBe(
+      "http://auth.apps.lastrev.localhost:3000",
+    );
+    expect(authHubOriginForHost("apps.lastrev.localhost:4000")).toBe(
+      "http://auth.apps.lastrev.localhost:4000",
+    );
+    expect(authHubOriginForHost("sentiment.lastrev.localhost:3000")).toBe(
+      "http://auth.lastrev.localhost:3000",
+    );
+  });
+
+  it("defaults the local-cluster port to :3000 when missing", () => {
+    expect(authHubOriginForHost("generations.apps.lastrev.localhost")).toBe(
+      "http://auth.apps.lastrev.localhost:3000",
+    );
+  });
+
+  it("treats bare localhost / 127.0.0.1 as same-origin (login lives there in dev)", () => {
+    expect(authHubOriginForHost("localhost:3000")).toBe(
+      "http://localhost:3000",
+    );
+    expect(authHubOriginForHost("localhost")).toBe("http://localhost:3000");
+    expect(authHubOriginForHost("127.0.0.1:3000")).toBe(
+      "http://localhost:3000",
+    );
+  });
+
+  it("treats Vercel preview hosts as same-origin", () => {
+    expect(authHubOriginForHost("lr-apps-git-feat-x.vercel.app")).toBe(
+      "https://lr-apps-git-feat-x.vercel.app",
+    );
+  });
+});
+
+describe("isAuthHubOrigin", () => {
+  it("is true for the auth subdomain on every cluster", () => {
+    expect(isAuthHubOrigin("auth.apps.lastrev.com")).toBe(true);
+    expect(isAuthHubOrigin("auth.lastrev.com")).toBe(true);
+    expect(isAuthHubOrigin("auth.apps.lastrev.localhost:3000")).toBe(true);
+    expect(isAuthHubOrigin("auth.lastrev.localhost:3000")).toBe(true);
+  });
+
+  it("is true for localhost and Vercel previews", () => {
+    expect(isAuthHubOrigin("localhost:3000")).toBe(true);
+    expect(isAuthHubOrigin("127.0.0.1")).toBe(true);
+    expect(isAuthHubOrigin("lr-apps-git-feat-x.vercel.app")).toBe(true);
+  });
+
+  it("is false for app subdomains where /login would loop", () => {
+    expect(isAuthHubOrigin("generations.apps.lastrev.com")).toBe(false);
+    expect(isAuthHubOrigin("sentiment.lastrev.com")).toBe(false);
+    expect(isAuthHubOrigin("apps.lastrev.com")).toBe(false);
+  });
+});
+
+describe("authHubUrl", () => {
+  it("stays relative when already on the auth hub", () => {
+    expect(authHubUrl("auth.apps.lastrev.com", "/login?redirect=foo")).toBe(
+      "/login?redirect=foo",
+    );
+    expect(authHubUrl("localhost:3000", "/login?redirect=foo")).toBe(
+      "/login?redirect=foo",
+    );
+  });
+
+  it("produces an absolute auth-hub URL on app subdomains", () => {
+    expect(
+      authHubUrl("generations.apps.lastrev.com", "/login?redirect=generations"),
+    ).toBe("https://auth.apps.lastrev.com/login?redirect=generations");
+
+    expect(
+      authHubUrl(
+        "generations.apps.lastrev.localhost:3000",
+        "/login?redirect=generations",
+      ),
+    ).toBe(
+      "http://auth.apps.lastrev.localhost:3000/login?redirect=generations",
+    );
+
+    expect(authHubUrl("sentiment.lastrev.com", "/unauthorized?app=sentiment")).toBe(
+      "https://auth.lastrev.com/unauthorized?app=sentiment",
+    );
+  });
+});

--- a/packages/auth/src/__tests__/require-access.edge-cases.test.ts
+++ b/packages/auth/src/__tests__/require-access.edge-cases.test.ts
@@ -6,15 +6,17 @@ vi.mock("next/navigation", () => ({
   },
 }));
 
+let mockHost = "localhost:3000";
+
 vi.mock("next/headers", () => ({
   headers: vi.fn().mockResolvedValue({
-    get: (key: string) => (key === "host" ? "localhost:3000" : null),
+    get: (key: string) => (key === "host" ? mockHost : null),
   }),
 }));
 
 vi.mock("../auth0-factory", () => ({
   getAuth0ClientForHost: vi.fn(),
-  getHostFromRequestHeaders: vi.fn(() => "localhost:3000"),
+  getHostFromRequestHeaders: vi.fn(() => mockHost),
 }));
 
 vi.mock("@repo/db/server", () => ({
@@ -31,6 +33,7 @@ const mockCreateClient = vi.mocked(createClient);
 describe("requireAccess edge cases", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHost = "localhost:3000";
   });
 
   describe("unauthenticated", () => {
@@ -40,6 +43,26 @@ describe("requireAccess edge cases", () => {
 
       await expect(requireAccess("sentiment")).rejects.toThrow(
         /REDIRECT:\/login\?redirect=sentiment/,
+      );
+    });
+
+    it("redirects to the auth-hub absolute URL on an app subdomain (avoids loop)", async () => {
+      mockHost = "generations.apps.lastrev.com";
+      const getSession = vi.fn().mockResolvedValue(null);
+      mockGetAuth0ClientForHost.mockReturnValue({ getSession } as never);
+
+      await expect(requireAccess("generations")).rejects.toThrow(
+        /REDIRECT:https:\/\/auth\.apps\.lastrev\.com\/login\?redirect=generations/,
+      );
+    });
+
+    it("redirects to the legacy auth hub on the legacy cluster", async () => {
+      mockHost = "sentiment.lastrev.com";
+      const getSession = vi.fn().mockResolvedValue(null);
+      mockGetAuth0ClientForHost.mockReturnValue({ getSession } as never);
+
+      await expect(requireAccess("sentiment")).rejects.toThrow(
+        /REDIRECT:https:\/\/auth\.lastrev\.com\/login\?redirect=sentiment/,
       );
     });
 

--- a/packages/auth/src/cluster-host.ts
+++ b/packages/auth/src/cluster-host.ts
@@ -1,0 +1,92 @@
+/**
+ * Auth-hub origin resolution for the Last Rev apps cluster.
+ *
+ * `/login`, `/signup`, `/unauthorized` only have a real page on the auth hub
+ * (e.g. `auth.apps.lastrev.com`). On any other subdomain the proxy rewrites
+ * those paths into the app's route group, where the layout's `requireAccess`
+ * fires and redirects again — a relative redirect to `/login` would loop.
+ *
+ * Mirrors the cluster classifier in `apps/web/lib/app-host.ts`. Duplicated
+ * here so `packages/auth` can stay free of an `apps/web` dependency.
+ */
+
+const APPS_ROOT_DOMAIN = "apps.lastrev.com";
+const APPS_ROOT_DOMAIN_LOCAL = "apps.lastrev.localhost";
+const LEGACY_ROOT_DOMAIN = "lastrev.com";
+const LEGACY_ROOT_DOMAIN_LOCAL = "lastrev.localhost";
+
+function portSuffix(hostHeader: string): string {
+  const i = hostHeader.indexOf(":");
+  return i === -1 ? "" : hostHeader.slice(i);
+}
+
+/**
+ * Origin (`scheme://host[:port]`) of the auth hub for the cluster of `host`.
+ * - `*.apps.lastrev.com` → `https://auth.apps.lastrev.com`
+ * - `*.apps.lastrev.localhost:3000` → `http://auth.apps.lastrev.localhost:3000`
+ * - legacy `*.lastrev.com` → `https://auth.lastrev.com`
+ * - legacy `*.lastrev.localhost:3000` → `http://auth.lastrev.localhost:3000`
+ * - bare `localhost` / `127.0.0.1` → `http://localhost[:port]` (login lives on the same origin in dev)
+ * - `*.vercel.app` → `https://<host>` (preview hosts; login lives on the same origin)
+ * - anything else → `https://<host>` (treat as same-origin)
+ */
+export function authHubOriginForHost(host: string): string {
+  const raw = host.trim();
+  const hostname = raw.split(":")[0].toLowerCase();
+  const port = portSuffix(raw);
+
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
+    return `http://localhost${port || ":3000"}`;
+  }
+  if (hostname.endsWith(".vercel.app")) {
+    return `https://${raw}`;
+  }
+  if (hostname === APPS_ROOT_DOMAIN || hostname.endsWith(`.${APPS_ROOT_DOMAIN}`)) {
+    return `https://auth.${APPS_ROOT_DOMAIN}`;
+  }
+  if (
+    hostname === APPS_ROOT_DOMAIN_LOCAL ||
+    hostname.endsWith(`.${APPS_ROOT_DOMAIN_LOCAL}`)
+  ) {
+    return `http://auth.${APPS_ROOT_DOMAIN_LOCAL}${port || ":3000"}`;
+  }
+  if (
+    hostname === LEGACY_ROOT_DOMAIN ||
+    hostname.endsWith(`.${LEGACY_ROOT_DOMAIN}`)
+  ) {
+    return `https://auth.${LEGACY_ROOT_DOMAIN}`;
+  }
+  if (
+    hostname === LEGACY_ROOT_DOMAIN_LOCAL ||
+    hostname.endsWith(`.${LEGACY_ROOT_DOMAIN_LOCAL}`)
+  ) {
+    return `http://auth.${LEGACY_ROOT_DOMAIN_LOCAL}${port || ":3000"}`;
+  }
+  return `https://${raw}`;
+}
+
+/**
+ * True when `/login`, `/signup`, `/unauthorized` resolve to a real page on the
+ * current origin. False on app subdomains (`generations.apps.lastrev.com`),
+ * where those paths get rewritten into the app's route group and would loop.
+ */
+export function isAuthHubOrigin(host: string): boolean {
+  const hostname = host.trim().split(":")[0].toLowerCase();
+  if (hostname === "localhost" || hostname === "127.0.0.1") return true;
+  if (hostname.endsWith(".vercel.app")) return true;
+  if (hostname === `auth.${APPS_ROOT_DOMAIN}`) return true;
+  if (hostname === `auth.${APPS_ROOT_DOMAIN_LOCAL}`) return true;
+  if (hostname === `auth.${LEGACY_ROOT_DOMAIN}`) return true;
+  if (hostname === `auth.${LEGACY_ROOT_DOMAIN_LOCAL}`) return true;
+  return false;
+}
+
+/**
+ * Build a same-cluster URL for an auth-hub-only path (`/login`, `/signup`,
+ * `/unauthorized`, `/my-apps`). Stays relative when the current origin already
+ * is the auth hub (so existing tests and dev flows are unchanged).
+ */
+export function authHubUrl(host: string, pathAndQuery: string): string {
+  if (isAuthHubOrigin(host)) return pathAndQuery;
+  return `${authHubOriginForHost(host)}${pathAndQuery}`;
+}

--- a/packages/auth/src/require-access.ts
+++ b/packages/auth/src/require-access.ts
@@ -7,6 +7,7 @@ import {
   getAuth0ClientForHost,
   getHostFromRequestHeaders,
 } from "./auth0-factory";
+import { authHubUrl } from "./cluster-host";
 
 export interface AccessResult {
   user: {
@@ -29,7 +30,10 @@ export async function requireAccess(
     // Distinguish between no session and expired/invalid session
     const errorParam = session ? "&error=session_expired" : "";
     redirect(
-      `/login?redirect=${encodeURIComponent(appSlug)}${errorParam}`,
+      authHubUrl(
+        host,
+        `/login?redirect=${encodeURIComponent(appSlug)}${errorParam}`,
+      ),
     );
   }
 
@@ -47,7 +51,9 @@ export async function requireAccess(
     .single()) as { data: { permission: string } | null };
 
   if (!perm || !hasPermission(perm.permission as Permission, minPermission)) {
-    redirect(`/unauthorized?app=${encodeURIComponent(appSlug)}`);
+    redirect(
+      authHubUrl(host, `/unauthorized?app=${encodeURIComponent(appSlug)}`),
+    );
   }
 
   return {


### PR DESCRIPTION
## Summary

- Unauthenticated visits to `*.apps.lastrev.com/` (e.g. `generations.apps.lastrev.com/`) hit `ERR_TOO_MANY_REDIRECTS` because `requireAccess` did `redirect(\"/login?redirect=…\")` — the proxy rewrites that relative path back into `/apps/<slug>/login`, the app's layout fires `requireAccess` again, and the loop never terminates. `/login`, `/signup`, and `/unauthorized` only resolve on the auth hub (`auth.apps.lastrev.com`), so app subdomains must redirect cross-host.
- Adds `@repo/auth/cluster-host` (`authHubOriginForHost`, `isAuthHubOrigin`, `authHubUrl`). `authHubUrl(host, path)` stays relative on the auth hub, localhost, and Vercel previews and produces an absolute auth-hub URL on app subdomains. The cluster classifier mirrors `apps/web/lib/app-host.ts` so `packages/auth` stays free of an `apps/web` dependency.
- Wraps every redirect target in `requireAccess` and `apps/web/app/(auth)/(forms)/unauthorized/actions.ts` (`requestAppAccess`) with `authHubUrl`.

## Test plan

- [x] `pnpm --filter @repo/auth test` — 83/83 passing, including 11 new `cluster-host` tests and 2 new `require-access.edge-cases` cases covering apps-cluster and legacy-cluster redirect targets.
- [x] `pnpm --filter @repo/web test __tests__/proxy.integration.test.ts` — 24/24 passing.
- [x] `pnpm --filter @repo/web test lib/__tests__` — 195/195 passing.
- [x] `pnpm --filter @repo/web test app/apps/generations` — 35/35 passing.
- [ ] After deploy: open an incognito window, visit `https://generations.apps.lastrev.com/` and confirm a single 3xx hop to `https://auth.apps.lastrev.com/login?redirect=generations` (no loop). Repeat for at least one other gated app (`sentiment`, `command-center`).
- [ ] Confirm `auth.apps.lastrev.com/login`, localhost (`?app=generations`), and a Vercel preview still serve a relative redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)