### PR TITLE
fix: ideas table types + Supabase client generic alignment

### DIFF
--- a/packages/db/src/server.ts
+++ b/packages/db/src/server.ts
@@ -1,5 +1,6 @@
 import { createServerClient, type SetAllCookies } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "./types";
 
 const isProduction = process.env.NODE_ENV === "production";
@@ -12,10 +13,19 @@ function serverSupabaseKey(): string {
   );
 }
 
-export async function createClient() {
+// Explicit return type — `@supabase/ssr@0.6` declares `createServerClient`
+// as `SupabaseClient<Database, SchemaName, Schema>` (3 generics) while
+// `SupabaseClient` actually takes 5 (Database, SchemaNameOrClientOptions,
+// SchemaName, Schema, ClientOptions). The mis-aligned positional generics
+// shift `Schema` into the `SchemaName` slot at the call site, which makes
+// the real `Schema` collapse to `never` and every `from(table).insert(...)`
+// reject its values as assignable to `never`. The cast through `unknown`
+// re-aligns the parameters to the canonical SupabaseClient<Database> shape
+// callers expect; we revisit if @supabase/ssr fixes its declaration.
+export async function createClient(): Promise<SupabaseClient<Database>> {
   const cookieStore = await cookies();
 
-  return createServerClient<Database>(
+  const client = createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     serverSupabaseKey(),
     {
@@ -39,4 +49,5 @@ export async function createClient() {
       },
     },
   );
+  return client as unknown as SupabaseClient<Database>;
 }

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -55,6 +55,47 @@ export type FeatureFlagRow = {
   created_at: string;
 };
 
+// Mirrors `supabase/migrations/20260429_ideas.sql`. Mixed naming is intentional:
+// `id`, `user_id`, `title`, etc. are unquoted (snake_case) while the camelCase
+// columns are quoted in the migration so the app code in apps/web/app/apps/ideas
+// can use them without an adapter layer.
+export type IdeaStatus =
+  | "new"
+  | "backlog"
+  | "in-progress"
+  | "completed"
+  | "archived";
+
+export type IdeaSource = "generated" | "community" | "manual";
+
+export type IdeaEffort = "Low" | "Medium" | "High";
+
+export type IdeaRow = {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string | null;
+  category: string | null;
+  status: IdeaStatus;
+  source: IdeaSource;
+  feasibility: number | null;
+  impact: number | null;
+  effort: IdeaEffort | null;
+  compositeScore: number | null;
+  rating: number | null;
+  hidden: boolean;
+  snoozedUntil: string | null;
+  tags: string[];
+  author: string | null;
+  sourceUrl: string | null;
+  plan: string | null;
+  planModel: string | null;
+  planGeneratedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export interface Database {
   public: {
     Tables: {
@@ -90,6 +131,18 @@ export interface Database {
         Insert: Pick<FeatureFlagRow, "key"> &
           Partial<Omit<FeatureFlagRow, "id" | "created_at">>;
         Update: Partial<Omit<FeatureFlagRow, "id" | "created_at">>;
+        Relationships: [];
+      };
+      ideas: {
+        Row: IdeaRow;
+        Insert: Pick<IdeaRow, "user_id" | "title"> &
+          Partial<
+            Omit<
+              IdeaRow,
+              "id" | "user_id" | "title" | "createdAt" | "updatedAt"
+            >
+          >;
+        Update: Partial<Omit<IdeaRow, "id" | "user_id" | "createdAt">>;
         Relationships: [];
       };
     };


### PR DESCRIPTION
## Summary

Vercel build of `session/021-ideas-app-promotion-to-standalone-mini-app` (#355) failed at `apps/web/app/apps/ideas/actions.ts:84` with `Argument of type '{ user_id: string; title: string; … }' is not assignable to parameter of type 'never'`. Two underlying problems, fixed together:

1. **Missing `ideas` table on the Database type.** `packages/db/src/types.ts` defines the typed schema for Supabase but never had `ideas` — even with a correctly typed client, `c.from(\"ideas\")` had no row/insert/update shape. Adds `IdeaRow`, `IdeaStatus`, `IdeaSource`, `IdeaEffort`, and an `ideas` entry mirroring the camel/snake column mix in `supabase/migrations/20260429_ideas.sql`.
2. **Mis-aligned `@supabase/ssr` generics.** `@supabase/ssr@0.6` declares `createServerClient<Database, SchemaName, Schema>` (3 generics), but the underlying `SupabaseClient` takes 5 (`Database`, `SchemaNameOrClientOptions`, `SchemaName`, `Schema`, `ClientOptions`). The mis-aligned positional generics shift `Schema` into the `SchemaName` slot at the call site, which collapses the real `Schema` to `never`. The result: **every** `from(table).insert(...)` on the typed client — not just `ideas` — was being rejected, the new `ideas` insert just happened to be the file the build hit first. Pins `createClient`'s return type to `SupabaseClient<Database>` and re-aligns the generics through an `unknown` cast inside the package so callers get the canonical typed client.

Verified with a minimal repro that `c.from(\"app_permissions\").insert(...)` was *also* failing on this branch with the same `never` collapse — so #2 affects far more than the new ideas app.

## Test plan

- [x] `pnpm --filter @repo/web build` completes the TypeScript phase that previously failed.
- [x] `pnpm --filter @repo/web exec tsc --noEmit` — the only remaining errors (16) are pre-existing in `app/apps/uptime/__tests__/page.test.tsx` and `app/apps/sentiment/__tests__/page.test.tsx`, both present on `main` before this branch.
- [x] `pnpm --filter @repo/web test app/apps/ideas` — 32/32 passing.
- [x] `pnpm --filter @repo/db test` — 41/41 passing.
- [ ] Vercel preview deploy of this branch should now reach the bundling phase and complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)