### PR TITLE
fix: strip Next.js route-group segments from proxy rewrite

### DIFF
--- a/apps/web/__tests__/proxy.integration.test.ts
+++ b/apps/web/__tests__/proxy.integration.test.ts
@@ -150,17 +150,37 @@ describe("proxy middleware integration", () => {
       expect(urlLegacy.pathname).toBe("/apps/sentiment/dashboard");
     });
 
-    it("recognizes auth.apps.lastrev.com as the auth hub route group", async () => {
+    it("rewrites auth.apps.lastrev.com paths without a route-group prefix", async () => {
+      // `(auth)` is a Next.js route group — invisible in URLs. Rewriting to
+      // `/(auth)/login` 404s because no URL contains a literal `(auth)`
+      // segment; the page at `app/(auth)/(forms)/login/page.tsx` actually
+      // serves `/login`. The proxy must leave the path alone.
       const req = makeRequest(
-        "https://auth.apps.lastrev.com/some-page",
+        "https://auth.apps.lastrev.com/login",
         "auth.apps.lastrev.com",
       );
       const res = await proxy(req);
       const rewrite = res.headers.get("x-middleware-rewrite");
       expect(rewrite).toBeTruthy();
       const url = new URL(rewrite!);
-      expect(url.pathname).toBe("/(auth)/some-page");
+      expect(url.pathname).toBe("/login");
     });
+
+    it.each(["/login", "/signup", "/unauthorized", "/my-apps", "/account"])(
+      "leaves %s unchanged on auth.apps.lastrev.com (route-group page)",
+      async (path) => {
+        middlewareMock.mockResolvedValueOnce(freshAuthResponse());
+        const req = makeRequest(
+          `https://auth.apps.lastrev.com${path}`,
+          "auth.apps.lastrev.com",
+        );
+        const res = await proxy(req);
+        const rewrite = res.headers.get("x-middleware-rewrite");
+        expect(rewrite, `auth hub should rewrite ${path}`).toBeTruthy();
+        const url = new URL(rewrite!);
+        expect(url.pathname).toBe(path);
+      },
+    );
   });
 
   describe("bare apps host (no subdomain)", () => {

--- a/apps/web/lib/__tests__/proxy-utils.test.ts
+++ b/apps/web/lib/__tests__/proxy-utils.test.ts
@@ -96,8 +96,11 @@ describe("proxy-utils", () => {
       expect(getRouteForSubdomain("sentiment")).toBe("/apps/sentiment");
     });
 
-    it("maps auth subdomain to auth route group", () => {
-      expect(getRouteForSubdomain("auth")).toBe("/(auth)");
+    it("maps auth subdomain to an empty URL prefix (route group lives on disk only)", () => {
+      // `(auth)` is a Next.js route group — invisible in URLs, so we strip it.
+      // The proxy leaves `/login` as `/login` so it resolves to
+      // `app/(auth)/(forms)/login/page.tsx` instead of 404'ing on `/(auth)/login`.
+      expect(getRouteForSubdomain("auth")).toBe("");
     });
 
     it("maps command-center subdomain", () => {
@@ -165,7 +168,8 @@ describe("proxy-utils", () => {
         const route = getRouteForSubdomain(app.subdomain);
         expect(route, `subdomain ${app.subdomain} must resolve`).not.toBeNull();
         if (app.slug === "auth") {
-          expect(route).toBe("/(auth)");
+          // `(auth)` is a route group; URL prefix is empty.
+          expect(route).toBe("");
         } else {
           expect(route).toBe(`/apps/${app.slug}`);
         }

--- a/apps/web/lib/proxy-utils.ts
+++ b/apps/web/lib/proxy-utils.ts
@@ -44,10 +44,28 @@ export function resolveSubdomain(host: string): string | null {
   return sub;
 }
 
+/**
+ * URL-space prefix for `subdomain`'s route group, ready to prepend to the
+ * incoming pathname inside `proxy.ts`.
+ *
+ * Strips Next.js route group segments — names wrapped in parens like
+ * `(auth)` — because they exist only on the filesystem and are not part
+ * of any URL Next.js will route. Rewriting to `/(auth)/login` 404s since
+ * no URL contains a literal `(auth)` segment; the
+ * `app/(auth)/(forms)/login/page.tsx` page actually serves `/login`.
+ *
+ * - `null` → unknown subdomain (caller redirects to the auth hub).
+ * - `""` → known subdomain whose routeGroup is purely Next.js route groups
+ *   (e.g. `auth` → `(auth)`); proxy leaves the pathname unchanged.
+ * - `"/apps/<slug>"` → standard app route-group prefix.
+ */
 export function getRouteForSubdomain(subdomain: string): string | null {
   const app = getAppBySubdomain(subdomain);
   if (!app) return null;
-  return `/${app.routeGroup}`;
+  const urlSegments = app.routeGroup
+    .split("/")
+    .filter((seg) => !(seg.startsWith("(") && seg.endsWith(")")));
+  return urlSegments.length === 0 ? "" : `/${urlSegments.join("/")}`;
 }
 
 /**

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -86,7 +86,7 @@ async function proxyImpl(request: NextRequest): Promise<NextResponse> {
     const appParam = request.nextUrl.searchParams.get("app");
     if (appParam) {
       const routePath = getRouteForSubdomain(appParam);
-      if (routePath) {
+      if (routePath !== null) {
         const devPathname = request.nextUrl.pathname;
         const url = request.nextUrl.clone();
         url.searchParams.delete("app");
@@ -120,7 +120,7 @@ async function proxyImpl(request: NextRequest): Promise<NextResponse> {
 
       const routePath = getRouteForSubdomain(subdomain);
 
-      if (!routePath) {
+      if (routePath === null) {
         return applyCspHeader(
           mergeAuthMiddlewareResponse(
             authResponse,


### PR DESCRIPTION
## Summary

- After #357 went out, an unauthed visit to e.g. `lighthouse.apps.lastrev.com/` correctly redirected to `https://auth.apps.lastrev.com/login?redirect=lighthouse` — but that URL returned **404**. Root cause: the proxy was rewriting `/login` on the auth subdomain to `/(auth)/login`. Next.js route groups (folder names wrapped in parens) only exist on the filesystem; they are invisible in URLs, so no route ever matched a literal `(auth)` segment. The page at `app/(auth)/(forms)/login/page.tsx` actually serves `/login`.
- `getRouteForSubdomain` now drops route-group segments from the URL prefix it returns. `auth` (`routeGroup: \"(auth)\"`) resolves to `\"\"` (empty prefix → leave path alone), while real app subdomains keep their `/apps/<slug>` prefix. The proxy's `if (!routePath)` guard becomes `if (routePath === null)` so the empty string still passes through to the rewrite step instead of being treated as an unknown subdomain.
- Same fix protects `/login`, `/signup`, `/unauthorized`, `/my-apps`, `/account` — every page in the `(auth)` route group reached via the auth hub. Without this fix every cross-host auth redirect from an app subdomain landed on a 404.

## Test plan

- [x] `pnpm --filter @repo/web test __tests__/proxy.integration.test.ts lib/__tests__/proxy-utils.test.ts` — 57/57 passing, including 5 new `it.each` cases covering `/login`, `/signup`, `/unauthorized`, `/my-apps`, `/account` rewrites on `auth.apps.lastrev.com`.
- [x] `pnpm --filter @repo/web test lib/__tests__ __tests__` — 929/929 passing.
- [x] `pnpm --filter @repo/web build` completes successfully.
- [ ] After deploy: open an incognito window, visit `https://lighthouse.apps.lastrev.com/`, and confirm the redirect to `https://auth.apps.lastrev.com/login?redirect=lighthouse` now renders the login page (no 404). Spot-check `/signup`, `/unauthorized?app=lighthouse`, `/my-apps` on the auth hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)