### PR TITLE
fix: derive Auth0 appBaseUrl per host so /auth/login validates

### DIFF
--- a/packages/auth/src/__tests__/auth0-factory.test.ts
+++ b/packages/auth/src/__tests__/auth0-factory.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+const { Auth0ClientMock } = vi.hoisted(() => ({
+  Auth0ClientMock: vi.fn().mockImplementation(() => ({ __mocked: true })),
+}));
+
 vi.mock("@auth0/nextjs-auth0/server", () => ({
-  Auth0Client: vi.fn().mockImplementation(() => ({ __mocked: true })),
+  Auth0Client: Auth0ClientMock,
 }));
 
 vi.mock("next/server", () => ({
@@ -48,6 +52,7 @@ describe("getHostFromRequestHeaders", () => {
 describe("getAuth0ClientForHost", () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
+    Auth0ClientMock.mockClear();
   });
 
   it("returns a client when AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET are set", () => {
@@ -118,6 +123,77 @@ describe("getAuth0ClientForHost", () => {
 
     const client = getAuth0ClientForHost("any-host-unique-777.example.com");
     expect(client).toBeDefined();
+  });
+
+  describe("appBaseUrl derivation", () => {
+    // Use a unique clientId per test so the module-level clientCache (keyed
+    // by `${clientId}|${host}`) cannot leak entries between tests.
+    let clientIdCounter = 0;
+    const uniqueClientId = () => `test-client-derive-${++clientIdCounter}`;
+
+    beforeEach(() => {
+      vi.stubEnv("AUTH0_CLIENT_ID", uniqueClientId());
+      vi.stubEnv("AUTH0_CLIENT_SECRET", "test-secret");
+      vi.stubEnv("AUTH0_DOMAIN", "test.auth0.com");
+      vi.stubEnv("AUTH0_SECRET", "very-long-secret-derive");
+      vi.stubEnv("AUTH0_PRODUCTS_JSON", "");
+    });
+
+    it("includes the request's own origin so /auth/login validates", () => {
+      vi.stubEnv("AUTH0_ALLOWED_BASE_URLS", "");
+      vi.stubEnv("APP_BASE_URL", "https://apps.lastrev.com");
+
+      getAuth0ClientForHost("auth.apps.lastrev.com");
+
+      const opts = Auth0ClientMock.mock.calls.at(-1)?.[0];
+      expect(opts.appBaseUrl).toContain("https://auth.apps.lastrev.com");
+    });
+
+    it("includes the auth hub for the cluster (post-redirect /auth/* calls)", () => {
+      vi.stubEnv("AUTH0_ALLOWED_BASE_URLS", "");
+      vi.stubEnv("APP_BASE_URL", "https://apps.lastrev.com");
+
+      getAuth0ClientForHost("lighthouse.apps.lastrev.com");
+
+      const opts = Auth0ClientMock.mock.calls.at(-1)?.[0];
+      expect(opts.appBaseUrl).toEqual(
+        expect.arrayContaining([
+          "https://lighthouse.apps.lastrev.com",
+          "https://auth.apps.lastrev.com",
+        ]),
+      );
+    });
+
+    it("unions env-var entries with derived origins, deduped", () => {
+      vi.stubEnv(
+        "AUTH0_ALLOWED_BASE_URLS",
+        "https://apps.lastrev.com,https://auth.apps.lastrev.com,https://staging.apps.lastrev.com",
+      );
+
+      getAuth0ClientForHost("auth.apps.lastrev.com");
+
+      const opts = Auth0ClientMock.mock.calls.at(-1)?.[0];
+      const seen = new Set(opts.appBaseUrl);
+      expect(seen.size).toBe(opts.appBaseUrl.length);
+      expect(seen).toContain("https://apps.lastrev.com");
+      expect(seen).toContain("https://auth.apps.lastrev.com");
+      expect(seen).toContain("https://staging.apps.lastrev.com");
+    });
+
+    it("caches per (clientId, host) so each subdomain gets its own appBaseUrl", () => {
+      vi.stubEnv("AUTH0_ALLOWED_BASE_URLS", "");
+      // Counter from beforeEach already moved this test to a fresh clientId,
+      // so the cache starts empty for this clientId.
+      const callsBefore = Auth0ClientMock.mock.calls.length;
+
+      getAuth0ClientForHost("lighthouse.apps.lastrev.com");
+      getAuth0ClientForHost("generations.apps.lastrev.com");
+      // Same host hits the cache and does not reconstruct.
+      getAuth0ClientForHost("lighthouse.apps.lastrev.com");
+
+      const callsAfter = Auth0ClientMock.mock.calls.length;
+      expect(callsAfter - callsBefore).toBe(2);
+    });
   });
 });
 

--- a/packages/auth/src/__tests__/cluster-host.test.ts
+++ b/packages/auth/src/__tests__/cluster-host.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
+  appBaseUrlsForHost,
   authHubOriginForHost,
   authHubUrl,
   isAuthHubOrigin,
+  requestOriginForHost,
 } from "../cluster-host";
 
 describe("authHubOriginForHost", () => {
@@ -110,5 +112,62 @@ describe("authHubUrl", () => {
     expect(authHubUrl("sentiment.lastrev.com", "/unauthorized?app=sentiment")).toBe(
       "https://auth.lastrev.com/unauthorized?app=sentiment",
     );
+  });
+});
+
+describe("requestOriginForHost", () => {
+  it("uses https for production hosts", () => {
+    expect(requestOriginForHost("lighthouse.apps.lastrev.com")).toBe(
+      "https://lighthouse.apps.lastrev.com",
+    );
+    expect(requestOriginForHost("auth.apps.lastrev.com")).toBe(
+      "https://auth.apps.lastrev.com",
+    );
+  });
+
+  it("uses http for localhost and *.localhost mirrors (port preserved)", () => {
+    expect(requestOriginForHost("localhost:3000")).toBe(
+      "http://localhost:3000",
+    );
+    expect(requestOriginForHost("auth.apps.lastrev.localhost:3000")).toBe(
+      "http://auth.apps.lastrev.localhost:3000",
+    );
+  });
+
+  it("uses https for Vercel preview hosts", () => {
+    expect(requestOriginForHost("lr-apps-git-feat-x.vercel.app")).toBe(
+      "https://lr-apps-git-feat-x.vercel.app",
+    );
+  });
+});
+
+describe("appBaseUrlsForHost", () => {
+  it("includes both the request's origin and the cluster auth hub on app subdomains", () => {
+    expect(appBaseUrlsForHost("lighthouse.apps.lastrev.com")).toEqual([
+      "https://lighthouse.apps.lastrev.com",
+      "https://auth.apps.lastrev.com",
+    ]);
+    expect(appBaseUrlsForHost("sentiment.lastrev.com")).toEqual([
+      "https://sentiment.lastrev.com",
+      "https://auth.lastrev.com",
+    ]);
+  });
+
+  it("dedupes when the request is already on the auth hub", () => {
+    expect(appBaseUrlsForHost("auth.apps.lastrev.com")).toEqual([
+      "https://auth.apps.lastrev.com",
+    ]);
+  });
+
+  it("returns the single localhost origin in dev (auth hub is the same origin)", () => {
+    expect(appBaseUrlsForHost("localhost:3000")).toEqual([
+      "http://localhost:3000",
+    ]);
+  });
+
+  it("returns the single preview origin on Vercel previews", () => {
+    expect(appBaseUrlsForHost("lr-apps-git-feat-x.vercel.app")).toEqual([
+      "https://lr-apps-git-feat-x.vercel.app",
+    ]);
   });
 });

--- a/packages/auth/src/auth0-factory.ts
+++ b/packages/auth/src/auth0-factory.ts
@@ -5,6 +5,7 @@ import { logAuditEvent } from "@repo/db/audit";
 import { createServiceRoleClient } from "@repo/db/service-role";
 import { capture } from "@repo/analytics/server";
 import { maybeSelfEnrollAfterLogin, appSlugFromReturnTo } from "./self-enroll";
+import { appBaseUrlsForHost } from "./cluster-host";
 
 const ALLOWED_RETURN_HOSTS = [
   "apps.lastrev.com",
@@ -85,21 +86,34 @@ const clientCache = new Map<string, Auth0Client>();
 
 /**
  * Host header value (may include port), e.g. `accounts.apps.lastrev.com` or `localhost:3000`.
- * Use one Auth0 tenant; use AUTH0_PRODUCTS_JSON for per-host client ID/secret (separate Auth0 applications per product).
+ *
+ * `Auth0Client` validates that every incoming request's origin is present in
+ * its `appBaseUrl` array — otherwise `/auth/login` throws `InvalidConfigurationError`.
+ * Static env-var lists fall out of date as new subdomains land, so we always
+ * union the per-host derived origins (current host + cluster auth hub) into
+ * whatever `AUTH0_ALLOWED_BASE_URLS` / `APP_BASE_URL` provides. The cache is
+ * keyed by `clientId|host` because the client's `appBaseUrl` is fixed at
+ * construction; each host needs its own cached client.
+ *
+ * Use one Auth0 tenant; use AUTH0_PRODUCTS_JSON for per-host client ID/secret
+ * (separate Auth0 applications per product).
  */
 export function getAuth0ClientForHost(host: string): Auth0Client {
   const cfg = resolveProductConfig(host);
-  const cacheKey = cfg.clientId;
+  const cacheKey = `${cfg.clientId}|${host.toLowerCase()}`;
   const existing = clientCache.get(cacheKey);
   if (existing) return existing;
 
-  const allowList = parseAllowList();
+  const envEntries = parseAllowList();
+  const derived = appBaseUrlsForHost(host);
+  const appBaseUrl = [...new Set([...derived, ...envEntries])];
+
   const client = new Auth0Client({
     domain: process.env.AUTH0_DOMAIN,
     clientId: cfg.clientId,
     clientSecret: cfg.clientSecret,
     secret: process.env.AUTH0_SECRET,
-    ...(allowList.length > 0 ? { appBaseUrl: allowList } : {}),
+    appBaseUrl,
     async onCallback(error, ctx, session) {
       const appBaseUrl =
         ctx.appBaseUrl ??

--- a/packages/auth/src/cluster-host.ts
+++ b/packages/auth/src/cluster-host.ts
@@ -90,3 +90,30 @@ export function authHubUrl(host: string, pathAndQuery: string): string {
   if (isAuthHubOrigin(host)) return pathAndQuery;
   return `${authHubOriginForHost(host)}${pathAndQuery}`;
 }
+
+/**
+ * Origin (`scheme://host[:port]`) of the request itself. `http` for localhost
+ * and `*.localhost` mirrors, `https` for everything else.
+ */
+export function requestOriginForHost(host: string): string {
+  const raw = host.trim();
+  const hostname = raw.split(":")[0].toLowerCase();
+  const isLocal =
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname.endsWith(".localhost");
+  return `${isLocal ? "http" : "https"}://${raw}`;
+}
+
+/**
+ * Origins Auth0 must accept as the `appBaseUrl` for a request from `host`.
+ * Auth0 v4 throws `InvalidConfigurationError` when the request origin isn't
+ * in `appBaseUrl`, so this always includes the current host plus the cluster's
+ * auth hub (so a follow-up call on `auth.<cluster>` after the cross-host
+ * redirect from `requireAccess` validates too).
+ */
+export function appBaseUrlsForHost(host: string): string[] {
+  const current = requestOriginForHost(host);
+  const hub = authHubOriginForHost(host);
+  return current === hub ? [current] : [current, hub];
+}


### PR DESCRIPTION
## Summary

- `https://auth.apps.lastrev.com/auth/login?returnTo=…` returned a 500 with `InvalidConfigurationError: APP_BASE_URL is not configured as a static string, and the APP_BASE_URL configuration does not contain a match for the current request origin.` Auth0 v4 validates that every request's origin appears in the `Auth0Client`'s `appBaseUrl` array; we built the array once at construction from `AUTH0_ALLOWED_BASE_URLS` / `APP_BASE_URL`, and that env-var list lagged behind the new `*.apps.lastrev.com` cluster.
- The fix builds the Auth0 client per `(clientId, host)` and derives the `appBaseUrl` from the request's host on every miss. The array always includes the request's own origin plus the cluster's auth hub, unioned with env-var entries. Adding a new app subdomain no longer requires bumping `AUTH0_ALLOWED_BASE_URLS` for `/auth/*` to work.
- Adds `requestOriginForHost(host)` and `appBaseUrlsForHost(host)` to `cluster-host.ts` — same classifier set (apps cluster, legacy cluster, local mirrors, bare localhost, Vercel previews) as the existing `authHubOriginForHost`.

## Separate issue noted (not in this PR)

Hitting `https://auth.apps.lastrev.com/auth/login` reproduces a second error after this fix: `Could not find the table 'public.lighthouse_sites' in the schema cache. Perhaps you meant the table 'public.lighthouse_audits'`. The repo has a `20260409_lighthouse.sql` migration that creates `lighthouse_sites`, but production appears to be on `lighthouse_audits`. That's a database/migration decision (run the migration vs. change the app code) — happy to address in a follow-up PR once you decide which side is canonical.

## Test plan

- [x] `pnpm --filter @repo/auth test` — 94/94 passing, including 4 new `appBaseUrl derivation` cases (current origin, auth hub, env-var union/dedupe, per-host caching) and 7 new `cluster-host` cases.
- [x] `pnpm --filter @repo/web build` completes cleanly.
- [ ] After deploy: open an incognito window, visit `https://lighthouse.apps.lastrev.com/`, confirm the `requireAccess` redirect to `https://auth.apps.lastrev.com/login?redirect=lighthouse` renders the login page, click Sign in, and confirm `/auth/login?returnTo=https://lighthouse.apps.lastrev.com/` issues the Auth0 redirect (no 500).
- [ ] Spot-check `/auth/login` directly on a non-hub subdomain (`https://generations.apps.lastrev.com/auth/login`) — the current host should now also satisfy `appBaseUrl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)