### PR TITLE
fix(lighthouse): query lighthouse_audits to match production schema

### DIFF
--- a/apps/web/app/apps/lighthouse/__tests__/page.test.tsx
+++ b/apps/web/app/apps/lighthouse/__tests__/page.test.tsx
@@ -30,10 +30,10 @@ const FIXTURE_RUN_1 = {
   bestPractices: 92,
   seo: 100,
   lcp: 1800,
-  fid: 50,
+  tbt: 50,
   cls: 0.05,
   fcp: 1200,
-  ttfb: 400,
+  si: 2.4,
   runAt: "2026-04-01T12:00:00Z",
 };
 
@@ -45,10 +45,10 @@ const FIXTURE_RUN_1_OLD = {
   bestPractices: 90,
   seo: 95,
   lcp: 2200,
-  fid: 80,
+  tbt: 80,
   cls: 0.08,
   fcp: 1500,
-  ttfb: 500,
+  si: 3.0,
   runAt: "2026-03-25T12:00:00Z",
 };
 
@@ -60,10 +60,10 @@ const FIXTURE_RUN_2 = {
   bestPractices: 58,
   seo: 80,
   lcp: 5000,
-  fid: 400,
+  tbt: 400,
   cls: 0.3,
   fcp: 3500,
-  ttfb: 2000,
+  si: 6.0,
   runAt: "2026-04-01T12:00:00Z",
 };
 

--- a/apps/web/app/apps/lighthouse/components/vitals-detail.tsx
+++ b/apps/web/app/apps/lighthouse/components/vitals-detail.tsx
@@ -5,18 +5,21 @@ import type { LighthouseRun } from "../lib/types";
 
 function vitalLevel(metric: string, value: number | null | undefined): "default" | "secondary" | "destructive" {
   if (value == null) return "secondary";
-  // Core Web Vitals thresholds
+  // Core Web Vitals + Lighthouse-lab thresholds (web.dev guidance).
+  // FID/TTFB were dropped in modern Lighthouse — TBT and SI replace them.
   if (metric === "lcp") return value <= 2500 ? "default" : value <= 4000 ? "secondary" : "destructive";
-  if (metric === "fid") return value <= 100 ? "default" : value <= 300 ? "secondary" : "destructive";
+  if (metric === "tbt") return value <= 200 ? "default" : value <= 600 ? "secondary" : "destructive";
   if (metric === "cls") return value <= 0.1 ? "default" : value <= 0.25 ? "secondary" : "destructive";
   if (metric === "fcp") return value <= 1800 ? "default" : value <= 3000 ? "secondary" : "destructive";
-  if (metric === "ttfb") return value <= 800 ? "default" : value <= 1800 ? "secondary" : "destructive";
+  // Speed Index is reported in seconds (e.g. 2.4), not ms.
+  if (metric === "si") return value <= 3.4 ? "default" : value <= 5.8 ? "secondary" : "destructive";
   return "secondary";
 }
 
 function formatValue(metric: string, value: number | null | undefined): string {
   if (value == null) return "—";
   if (metric === "cls") return value.toFixed(3);
+  if (metric === "si") return `${value.toFixed(1)}s`;
   return `${Math.round(value)}ms`;
 }
 
@@ -34,10 +37,10 @@ interface VitalsDetailProps {
 export function VitalsDetail({ run, siteName }: VitalsDetailProps) {
   const vitals = [
     { key: "lcp", label: "LCP", description: "Largest Contentful Paint", value: run.lcp },
-    { key: "fid", label: "FID", description: "First Input Delay", value: run.fid },
+    { key: "tbt", label: "TBT", description: "Total Blocking Time", value: run.tbt },
     { key: "cls", label: "CLS", description: "Cumulative Layout Shift", value: run.cls },
     { key: "fcp", label: "FCP", description: "First Contentful Paint", value: run.fcp },
-    { key: "ttfb", label: "TTFB", description: "Time to First Byte", value: run.ttfb },
+    { key: "si", label: "SI", description: "Speed Index", value: run.si },
   ];
 
   return (

--- a/apps/web/app/apps/lighthouse/lib/queries.ts
+++ b/apps/web/app/apps/lighthouse/lib/queries.ts
@@ -4,7 +4,7 @@ import type { LighthouseSite } from "./types";
 export async function getSites(): Promise<LighthouseSite[]> {
   const supabase = await createClient();
   const { data: sites, error } = await (supabase as any)
-    .from("lighthouse_sites")
+    .from("lighthouse_audits")
     .select("*, lighthouse_runs(id, performance, accessibility, best_practices, seo, lcp, fid, cls, fcp, ttfb, run_at)")
     .order("name", { ascending: true });
 

--- a/apps/web/app/apps/lighthouse/lib/queries.ts
+++ b/apps/web/app/apps/lighthouse/lib/queries.ts
@@ -1,47 +1,95 @@
 import { createClient } from "@repo/db/server";
-import type { LighthouseSite } from "./types";
+import type { LighthouseRun, LighthouseSite } from "./types";
+
+// Production schema (`public.lighthouse_audits`) is a single denormalized
+// table — no per-audit row, no FK to a runs table. Each row is one tracked
+// site with the audit history stored as a JSONB array under `audits`. Each
+// audit object looks like:
+//   { date, seo, performance, accessibility, bestPractices,
+//     details: { lcp, fcp, cls, tbt, si } }
+type AuditDetailsJson = {
+  lcp?: number | null;
+  fcp?: number | null;
+  cls?: number | null;
+  tbt?: number | null;
+  si?: number | null;
+};
+
+type AuditJson = {
+  date?: string | null;
+  seo?: number | null;
+  performance?: number | null;
+  accessibility?: number | null;
+  bestPractices?: number | null;
+  details?: AuditDetailsJson | null;
+};
+
+type LighthouseAuditRow = {
+  id: string;
+  site: string;
+  url: string | null;
+  audits: AuditJson[] | null;
+  createdAt: string | null;
+};
+
+function toRun(siteId: string, audit: AuditJson, idx: number): LighthouseRun {
+  const d = audit.details ?? {};
+  return {
+    // Audit objects in JSONB have no stable identity; pin the React list key
+    // to (site-id, array-index) which is stable across re-renders for a
+    // given DB row.
+    id: `${siteId}-${idx}`,
+    siteId,
+    performance: audit.performance ?? null,
+    accessibility: audit.accessibility ?? null,
+    bestPractices: audit.bestPractices ?? null,
+    seo: audit.seo ?? null,
+    lcp: d.lcp ?? null,
+    tbt: d.tbt ?? null,
+    cls: d.cls ?? null,
+    fcp: d.fcp ?? null,
+    si: d.si ?? null,
+    runAt: audit.date ?? null,
+  };
+}
 
 export async function getSites(): Promise<LighthouseSite[]> {
   const supabase = await createClient();
-  const { data: sites, error } = await (supabase as any)
+  const { data, error } = await (supabase as unknown as {
+    from: (t: string) => {
+      select: (cols: string) => {
+        order: (
+          col: string,
+          opts: { ascending: boolean },
+        ) => Promise<{ data: LighthouseAuditRow[] | null; error: unknown }>;
+      };
+    };
+  })
     .from("lighthouse_audits")
-    .select("*, lighthouse_runs(id, performance, accessibility, best_practices, seo, lcp, fid, cls, fcp, ttfb, run_at)")
-    .order("name", { ascending: true });
+    .select("id, site, url, audits, createdAt")
+    .order("site", { ascending: true });
 
   if (error) {
-    console.error("Failed to fetch lighthouse sites:", error);
+    console.error("Failed to fetch lighthouse audits:", error);
     return [];
   }
 
-  return (sites ?? []).map((row: any) => {
-    const runs: any[] = row.lighthouse_runs ?? [];
-    const sorted = runs.sort((a: any, b: any) =>
-      (a.run_at ?? "").localeCompare(b.run_at ?? "")
-    );
-    const latest = sorted.length > 0 ? sorted[sorted.length - 1] : null;
-
-    const mapRun = (r: any) => ({
-      id: r.id,
-      siteId: row.id,
-      performance: r.performance,
-      accessibility: r.accessibility,
-      bestPractices: r.best_practices,
-      seo: r.seo,
-      lcp: r.lcp,
-      fid: r.fid,
-      cls: r.cls,
-      fcp: r.fcp,
-      ttfb: r.ttfb,
-      runAt: r.run_at,
-    });
+  return (data ?? []).map((row): LighthouseSite => {
+    const audits = row.audits ?? [];
+    const runs = audits
+      .map((a, idx) => toRun(row.id, a, idx))
+      .sort((a, b) =>
+        (a.runAt ?? "").localeCompare(b.runAt ?? ""),
+      );
+    const latest = runs.length > 0 ? runs[runs.length - 1] : null;
 
     return {
       id: row.id,
-      name: row.name,
-      url: row.url,
-      createdAt: row.created_at,
-      latestRun: latest ? mapRun(latest) : null,
-      runs: sorted.map(mapRun),
+      name: row.site,
+      url: row.url ?? "",
+      createdAt: row.createdAt,
+      latestRun: latest,
+      runs,
     };
   });
 }

--- a/apps/web/app/apps/lighthouse/lib/types.ts
+++ b/apps/web/app/apps/lighthouse/lib/types.ts
@@ -7,6 +7,11 @@ export interface LighthouseSite {
   runs: LighthouseRun[];
 }
 
+// Mirrors the JSONB shape of `lighthouse_audits.audits[*]` in production.
+// `id` is synthesized at query time (`<site-id>-<index>`) so the React list
+// keys are stable; the DB rows have no per-audit identifier.
+// FID and TTFB were dropped in modern Lighthouse — TBT (Total Blocking Time)
+// and SI (Speed Index) replace them in `details`.
 export interface LighthouseRun {
   id: string;
   siteId: string;
@@ -15,9 +20,9 @@ export interface LighthouseRun {
   bestPractices?: number | null;
   seo?: number | null;
   lcp?: number | null;
-  fid?: number | null;
+  tbt?: number | null;
   cls?: number | null;
   fcp?: number | null;
-  ttfb?: number | null;
+  si?: number | null;
   runAt?: string | null;
 }

--- a/supabase/migrations/20260429_lighthouse_audits.down.sql
+++ b/supabase/migrations/20260429_lighthouse_audits.down.sql
@@ -1,0 +1,7 @@
+-- Reverses 20260429_lighthouse_audits.sql. Drops only what this migration
+-- created — it does NOT recreate the legacy lighthouse_sites /
+-- lighthouse_runs tables. Re-running 20260409_lighthouse.sql restores
+-- those if needed.
+
+drop policy if exists "lighthouse_audits_select" on public.lighthouse_audits;
+drop table if exists public.lighthouse_audits;

--- a/supabase/migrations/20260429_lighthouse_audits.sql
+++ b/supabase/migrations/20260429_lighthouse_audits.sql
@@ -1,0 +1,49 @@
+-- Aligns the dev/staging migration trail with the production schema for
+-- the Lighthouse mini-app. Production was provisioned outside this
+-- migration system as a single denormalized table (`public.lighthouse_audits`)
+-- where each row is one tracked site and the audit history lives in a
+-- JSONB array. The earlier `20260409_lighthouse.sql` migration created a
+-- normalized `lighthouse_sites` + `lighthouse_runs` pair that never made it
+-- to prod, and the app code now reads `lighthouse_audits` directly.
+--
+-- This migration is idempotent so it's safe to run against:
+--   - prod (table already exists; CREATE TABLE IF NOT EXISTS is a no-op),
+--   - dev/staging that previously applied 20260409 (legacy tables get dropped),
+--   - a fresh DB (creates lighthouse_audits cleanly).
+--
+-- Append-only per CLAUDE.md: the 20260409_lighthouse.sql files stay in place;
+-- this migration supersedes them by dropping their tables and creating the
+-- right one.
+
+drop table if exists public.lighthouse_runs cascade;
+drop table if exists public.lighthouse_sites cascade;
+
+create table if not exists public.lighthouse_audits (
+  id text primary key,
+  site text not null,
+  url text,
+  audits jsonb not null default '[]'::jsonb,
+  "createdAt" text,
+  "updatedAt" text
+);
+
+alter table public.lighthouse_audits enable row level security;
+
+-- Use a DO block so the create policy is conditional — production may
+-- already have its own read policy and `CREATE POLICY` doesn't support
+-- IF NOT EXISTS until Postgres 17.
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'lighthouse_audits'
+      and policyname = 'lighthouse_audits_select'
+  ) then
+    create policy "lighthouse_audits_select"
+      on public.lighthouse_audits for select
+      using (auth.role() = 'authenticated');
+  end if;
+end
+$$;


### PR DESCRIPTION
## Summary

Initial commit on this branch was a single-file rename of `.from("lighthouse_sites")` → `.from("lighthouse_audits")`. The follow-up commit makes the app actually work against production (which has a totally different shape than the in-repo migration), based on direct schema introspection (`GET /rest/v1/`):

```
public.lighthouse_audits
  id        text  PK
  site      text  NOT NULL
  url       text
  audits    jsonb           — denormalized audit history
  createdAt text
  updatedAt text
```

There is **no** `lighthouse_runs` table and **no** FK relationship — PostgREST cannot embed runs. Each `audits[*]` JSONB element looks like `{ date, seo, performance, accessibility, bestPractices, details: { lcp, fcp, cls, tbt, si } }` (FID and TTFB are gone in modern Lighthouse; TBT and SI replace them).

### App-code changes

- `lib/queries.ts` — reads columns directly (no embed), walks `audits` to build `LighthouseRun[]`, synthesizes a stable `${siteId}-${idx}` run id since JSONB items have no identity.
- `lib/types.ts` — `LighthouseRun` now exposes `tbt` and `si` instead of `fid` / `ttfb`.
- `components/vitals-detail.tsx` — TBT and SI replace FID and TTFB with the right thresholds (TBT ≤200/600 ms, SI ≤3.4/5.8 s; SI rendered as seconds).
- `__tests__/page.test.tsx` fixtures updated to the new shape.

### Migration cleanup (append-only per CLAUDE.md)

Adds `supabase/migrations/20260429_lighthouse_audits.sql` + `.down.sql`. The existing `20260409_lighthouse.*` files stay in place; the new migration supersedes them:

- Drops `lighthouse_runs` and `lighthouse_sites` (cleans up dev environments that previously applied the legacy migration; no-op on prod).
- `CREATE TABLE IF NOT EXISTS public.lighthouse_audits (…)` matching the live shape.
- Enables RLS and creates a SELECT policy via a `do $$ … if not exists … create policy …` block so it's idempotent on prod (which already has its own policy).
- Down only drops what this migration creates (legacy tables can be restored by re-running `20260409_lighthouse.sql` if needed).

## Test plan

- [x] Production introspection confirms keys: `audits, createdAt, id, site, url`; per-audit: `accessibility, bestPractices, date, details, performance, seo`; details: `cls, fcp, lcp, si, tbt`.
- [x] `pnpm --filter @repo/web test app/apps/lighthouse` — 10/10 passing.
- [x] `pnpm --filter @repo/web build` completes cleanly.
- [x] `pnpm db:check-migration-pairs` — 10 migrations, all paired.
- [ ] After deploy: visit `https://lighthouse.apps.lastrev.com/` and confirm sites render with scores; click a site and verify the score-history chart and the TBT/SI vitals tiles populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)