### PR TITLE
fix(db): migrate user_id columns from uuid to text for Auth0

### DIFF
--- a/supabase/migrations/20260429_user_id_text.down.sql
+++ b/supabase/migrations/20260429_user_id_text.down.sql
@@ -1,0 +1,15 @@
+-- Reverts the user_id text conversion back to uuid. Only safe on empty
+-- tables — Auth0 string IDs (e.g. "google-oauth2|...") cannot cast back
+-- to uuid. Clear the rows manually before applying if needed.
+--
+-- Note: the original RLS policies and FKs to auth.users are NOT restored
+-- here, since they were the bug being removed.
+
+alter table public.app_profiles
+  alter column user_id type uuid using user_id::uuid;
+
+alter table public.app_subscriptions
+  alter column user_id type uuid using user_id::uuid;
+
+alter table public.app_permissions
+  alter column user_id type uuid using user_id::uuid;

--- a/supabase/migrations/20260429_user_id_text.sql
+++ b/supabase/migrations/20260429_user_id_text.sql
@@ -1,0 +1,68 @@
+-- Auth0 emits string user IDs (e.g. "google-oauth2|...") that don't fit
+-- in `user_id uuid` columns. Switch the three user-keyed tables to text,
+-- drop the FKs to auth.users (Auth0 doesn't populate that table), and drop
+-- the RLS policies that reference auth.uid() = user_id (auth.uid() is null
+-- under Auth0, so they grant nothing today; access flows through the
+-- service-role client).
+--
+-- Existing rows are stale UUIDs from a Supabase-Auth-era setup and are not
+-- linked to any current Auth0 user — drop them. Users will be re-created on
+-- normal signup; Stripe webhooks will rebuild app_subscriptions on the next
+-- subscription event.
+
+-- 1. Drop policies that reference auth.uid() on these tables.
+do $$
+declare pol record;
+begin
+  for pol in
+    select schemaname, tablename, policyname
+    from pg_policies
+    where schemaname = 'public'
+      and tablename in ('app_permissions', 'app_subscriptions', 'app_profiles')
+      and (qual like '%auth.uid()%' or with_check like '%auth.uid()%')
+  loop
+    execute format('drop policy %I on %I.%I',
+                   pol.policyname, pol.schemaname, pol.tablename);
+  end loop;
+end $$;
+
+-- 2. Drop foreign keys to auth.users (constraint names may vary across envs).
+do $$
+declare c record;
+begin
+  for c in
+    select con.conname, rel.relname
+    from pg_constraint con
+    join pg_class rel on rel.oid = con.conrelid
+    join pg_namespace nsp on nsp.oid = rel.relnamespace
+    where nsp.nspname = 'public'
+      and rel.relname in ('app_permissions', 'app_subscriptions', 'app_profiles')
+      and con.contype = 'f'
+      and exists (
+        select 1 from pg_class r2
+        join pg_namespace n2 on n2.oid = r2.relnamespace
+        where r2.oid = con.confrelid
+          and n2.nspname = 'auth'
+          and r2.relname = 'users'
+      )
+  loop
+    execute format('alter table public.%I drop constraint %I',
+                   c.relname, c.conname);
+  end loop;
+end $$;
+
+-- 3. Drop stale rows so we can change the column type without conversion
+--    surprises. Users re-create on normal signup.
+delete from public.app_permissions;
+delete from public.app_subscriptions;
+delete from public.app_profiles;
+
+-- 4. Switch user_id to text on each table.
+alter table public.app_permissions
+  alter column user_id type text using user_id::text;
+
+alter table public.app_subscriptions
+  alter column user_id type text using user_id::text;
+
+alter table public.app_profiles
+  alter column user_id type text using user_id::text;


### PR DESCRIPTION
## Summary
Self-enroll on free-tier apps was hitting `22P02 invalid input syntax for type uuid: "google-oauth2|..."` — the `app_permissions`, `app_subscriptions`, and `app_profiles` tables had `user_id uuid REFERENCES auth.users(id)`, but Auth0 user IDs are strings, not UUIDs.

This migration:
1. Drops RLS policies that reference `auth.uid() = user_id` (always null under Auth0; service-role bypass is the actual access path).
2. Drops FKs to `auth.users` (Auth0 doesn't populate that table).
3. Deletes existing rows (stale synthetic UUIDs from a Supabase-Auth-era setup, not linked to any current Auth0 user — confirmed with project owner).
4. `ALTER COLUMN user_id TYPE text` on all three tables.

Defensive `DO $$ ... $$` blocks introspect `pg_policies` and `pg_constraint` to find policies/FKs by predicate rather than name, so it works against the live schema even though some constraint names diverge from the original `001_app_permissions.sql`/`002_subscriptions.sql` migrations.

## Live state findings
The migrations folder is partially aspirational. Live DB has tables not in repo (`app_subscriptions`, `app_profiles`, etc.) and lacks others that are in repo (`subscriptions`, `audit_log`, `feature_flags`). Audit done via the project's PostgREST swagger — only these three tables had `user_id uuid`; everything else either uses `text` (`workout_logs`, `personal_records`) or doesn't have a user_id column.

## Apply
Migration is **not auto-applied** — needs to run against prod manually via Supabase SQL Editor or `supabase db push --linked`.

## Test plan
- [x] `node --experimental-strip-types scripts/check-migration-pairs.ts` → 11 migrations, all paired.
- [ ] Apply migration to prod.
- [ ] Verify Lighthouse self-enroll: visit `https://lighthouse.apps.lastrev.com` → "Request access" → no `?error=closed` redirect; user gets routed into the app.
- [ ] Verify `app_permissions` row created with `user_id = "google-oauth2|..."` after self-enroll.

## Follow-ups (not in this PR)
- Stripe webhook will recreate `app_subscriptions` rows on next event for any active subscriptions.
- Consider whether the unused `subscriptions` / `audit_log` / `feature_flags` migrations should be removed from the repo, or applied to live to back the code paths that reference them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)