### PR TITLE
plan: e2e tests for HSPT Practice

### DIFF
--- a/docs/superpowers/plans/2026-04-30-alpha-wins-e2e-testing.md
+++ b/docs/superpowers/plans/2026-04-30-alpha-wins-e2e-testing.md
@@ -1,0 +1,71 @@
+# Plan: E2E tests for the Alpha Wins app
+
+> Drafted 2026-04-30. Slug `alpha-wins`, route `/apps/alpha-wins`, template `minimal`, tier `free`, auth required.
+
+Reuse existing infra — Playwright config (`apps/web/playwright.config.ts`), the `loggedInPage` fixture (`apps/web/tests/e2e/fixtures/auth.fixture.ts`), and `seedPermission` (`apps/web/tests/e2e/helpers/db.ts`). No new helper file needed: Alpha Wins has **no DB persistence**. The page renders a static gallery from `apps/web/app/apps/alpha-wins/data/wins.json` via the client component `WinsGallery`. There is nothing for a service-role client to seed or assert against, which is why the Ideas plan's `helpers/<slug>.ts` step is intentionally absent here.
+
+Component-level coverage already lives in `apps/web/app/apps/alpha-wins/__tests__/wins-gallery.test.tsx` (vitest + jsdom) and `__tests__/layout.test.tsx`. E2E only needs to prove the gated route + happy-path interactions work end-to-end through the real proxy + Auth0 + permission check.
+
+---
+
+## 1. Setup (one-time, prereq)
+
+- **Env vars**: `E2E_TEST_USER_EMAIL/PASSWORD/ID` (already used by the auth fixture and `auth.spec.ts`); `NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` for `seedPermission`.
+- **No new fixtures**: reuse `loggedInPage` and `unauthPage` from `auth.fixture.ts`.
+- **Permissions**: `beforeAll` calls `seedPermission(userId, "alpha-wins", "view")` (registry permission is `"view"`, not `"edit"` — do not bump it). `afterAll` calls `deletePermission` to keep tests independent of the auth suite.
+- **Self-enroll**: `alpha-wins` is `tier: "free"`, so `setSelfEnrollTierResolver` already lets the auth fixture's user self-enroll in dev mode. CI runs `next start`, so the test still seeds explicitly rather than relying on `APP_SELF_ENROLL_SLUGS` (which only lists `command-center,standup`).
+
+## 2. Test data strategy
+
+**None.** Wins ship in `data/wins.json` and are statically imported. Tests reference real win names from that file (e.g. `"Wins Channel — Share What You Build"`, `"Morning Weather Briefing"`) so we exercise the actual production payload, not a mock. If the file changes, the spec changes — that is the right coupling for a content-driven gallery.
+
+## 3. Use-case catalog (test inventory)
+
+### Group A — Access, gating, and core gallery interactions (smoke)
+
+1. **Unauth → login redirect.** `unauthPage` visits `/apps/alpha-wins`; expect redirect to `/auth/login` (or Auth0 universal login URL). Mirrors `auth.spec.ts` pattern.
+2. **Auth user without `alpha-wins` permission → unauthorized.** Delete the permission first, then `loggedInPage.goto`; expect `/unauthorized` (free tier auto-enroll only fires on the dev path; in `next start` we should land on unauthorized when permission is absent and self-enroll is off).
+3. **Auth user with `view` permission → page renders.** Header shows `"Alpha Wins"` and the subtitle `"Recent wins & accomplishments"`. The win-count badge (`{n} wins`) reflects `wins.json.length`.
+4. **Search filters the grid.** Type `"weather"` in the `Search wins…` input → `"Morning Weather Briefing"` is visible, `"Wins Channel — Share What You Build"` is not. Win-count badge updates to `1 win` (singular — guards the pluralization branch).
+5. **Search empty state.** Type `"zzznomatch"` → `"No wins match that filter"` renders.
+6. **Integration filter pill.** Click the `Slack` integration pill → grid narrows to wins whose `integrations` include Slack. Both seeded wins match, so we use a more selective filter when the dataset grows; today this asserts the filter pill is clickable and stays selected (accent style).
+7. **Category filter pill.** Click the `Workflow` category pill → only `type === "Workflow"` wins remain. Combined with #6, asserts the category-and-integration composition logic that the unit test already covers, but through the real route.
+8. **Open detail modal.** Click a win card → `role="dialog"` opens, title contains the win name, `"Setup Prompt"` section is present, and the `📋 Copy Prompt` button is rendered. Closing via Escape returns focus to the grid.
+
+That is the entire Group A. There is no Group B (no CRUD), no Group C/D/E (no status/snooze/sort), no Group G (no AI). Adding more groups would be padding — the unit tests in `__tests__/wins-gallery.test.tsx` already cover deeper filter composition, copy-to-clipboard, and empty-gallery edge cases at speed; e2e duplicating them adds flake without coverage.
+
+## 4. Spec organization
+
+```
+apps/web/tests/e2e/alpha-wins/
+  access.spec.ts   # cases 1–3 (gating)
+  gallery.spec.ts  # cases 4–8 (search, filters, modal)
+```
+
+Two files instead of one because the `beforeAll`/`afterAll` permission lifecycle differs: `access.spec.ts` toggles permission state mid-suite (case 2 deletes, case 3 re-seeds), while `gallery.spec.ts` keeps a stable seeded permission throughout. Splitting avoids leaking state between concerns.
+
+## 5. Selector strategy
+
+The component currently relies on text + a couple of `aria-label`s (`"Filter by category"`, `"Filter by integration"`). For the eight cases above, text + role selectors are stable enough — win names come from `wins.json` and rarely change, and pill buttons are queryable by `getByRole("button", { name: "Slack" })`. No `data-testid` additions required for this scope. If we later add CRUD or surface admin tooling, revisit then.
+
+Why no testids now: adding hooks for a static gallery of two cards is over-engineering. The unit test file uses identical selector patterns (`getByRole("button", { name: ... })`) and has been stable.
+
+## 6. Running
+
+- `pnpm --filter web test:e2e` — same script the Ideas plan and `auth.spec.ts` use.
+- Local: `reuseExistingServer: true` lets `pnpm dev` stay running between iterations.
+- CI: relies on `next build && next start` from `webServer.command`. Permission seeding must run before the page is fetched (already handled by `beforeAll`).
+
+## 7. Out of scope
+
+- Visual diffs of the glass-card hover/translate state — separate effort.
+- Verifying clipboard contents end-to-end (Playwright clipboard permissions are flaky across browsers; the unit test already mocks and asserts `clipboard.writeText` directly).
+- Re-asserting category/integration filter composition matrices — `wins-gallery.test.tsx` does this exhaustively.
+
+---
+
+## Execution order
+
+1. Write `access.spec.ts` (cases 1–3) — proves gating works, highest signal for routing/auth regressions.
+2. Write `gallery.spec.ts` (cases 4–8) — exercises the user-facing happy path through the real proxy.
+3. Run both locally with seeded perms; confirm tear-down leaves `app_permissions` clean.

--- a/docs/superpowers/plans/2026-04-30-generations-e2e-testing.md
+++ b/docs/superpowers/plans/2026-04-30-generations-e2e-testing.md
@@ -1,0 +1,153 @@
+# Plan: E2E tests for the Generations app
+
+> Drafted 2026-04-30. Companion plan to the Ideas e2e plan; structure mirrors that doc.
+
+Generations is a `template: "minimal"`, `tier: "pro"` app that ships a slang hub at `/apps/generations` plus a tabbed per-generation page at `/apps/generations/[gen]` (Dictionary / Translator / Quiz / Trending). All data is bundled JSON (`apps/web/app/apps/generations/data/*.json`) — there is no DB persistence, no server actions, no per-user state. That shapes this plan: e2e is mostly access/gating + client interactivity, not CRUD. We extend the existing Playwright infra (`apps/web/playwright.config.ts`, `loggedInPage` fixture, `helpers/db.ts` for permission seeding) — no new fixtures needed.
+
+---
+
+## 1. Setup (one-time, prereq)
+
+- **Env vars** (`.env.local` for local, GH secrets for CI):
+  - `E2E_TEST_USER_EMAIL`, `E2E_TEST_USER_PASSWORD`, `E2E_TEST_USER_ID` — already used by auth fixture (this is the Pro user; needs an active Pro subscription row when `tier_enforcement_enabled` flag is on)
+  - `E2E_TEST_USER_FREE_EMAIL/PASSWORD/ID` — second user on the free tier, used to drive the upgrade-gate flow (Group A test 5)
+  - `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` — already used
+- **No new fixtures**: reuse `loggedInPage` from `auth.fixture.ts`. The free-tier user spec gets a second context loaded with a different `storageState` file (or `loginWithAuth0` against a fresh context).
+- **Permissions**: in `beforeAll`, call `seedPermission(userId, "generations", "view")` — the registry entry has `permission: "view"`, no `publicRoutes`, no self-enroll override, so the gate is hard. Tear down in `afterAll`.
+- **Tier flag**: tests assume `tier_enforcement_enabled` is on for the Pro and free user IDs. If you toggle it off, Group A test 4/5 become no-ops (the layout returns access for all). Document the env in the spec header.
+
+## 2. Test data strategy
+
+No `tests/e2e/helpers/generations.ts` is needed. Justification:
+
+- The app reads from static JSON at build time (`./data/${slug}.json`); there is no `generations` table to seed or clean up.
+- All UI state (search query, active category pill, quiz progress, translator direction) lives in component `useState` and resets per page load — tests don't need cross-test cleanup.
+- Test data is the JSON fixtures themselves. Specs that need stable assertions (e.g. "the top trending term for gen-z is X") should pin against term IDs in `data/gen-z.json` rather than hard-coded strings, so editing the JSON doesn't silently break tests. Helper functions in the spec file (`pickTopTermForGen(slug)`) are fine.
+
+The only Supabase work is `seedPermission` / `deletePermission` from the existing `helpers/db.ts`, plus optionally a Pro subscription row via service-role insert into `subscriptions` — wrap that in a small `seedProSubscription(userId)` helper inside the existing `helpers/db.ts` if not already present, since this is the first `tier: "pro"` app the e2e suite covers end-to-end.
+
+## 3. Use-case catalog (test inventory)
+
+### Group A — Access & gating (smoke)
+
+1. Unauth user → `/apps/generations` redirects to login
+2. Auth user without `generations` permission → unauthorized page (no `publicRoutes` means even `/` is gated)
+3. Auth Pro user with `generations:view` permission → hub renders with header "Generations" and the 6 generation cards
+4. Auth free-tier user with permission but no Pro subscription, with `tier_enforcement_enabled` on → `UpgradePrompt` renders with "Pro Plan Required" + link to `/pricing`
+5. Free user clicks the pricing link → navigates to `/pricing` (sanity check, no checkout flow)
+
+### Group B — Hub navigation
+
+6. Hub renders all 6 generation chips (gen-alpha, gen-z, gen-y, gen-x, gen-boomers, gen-silent) in the hero
+7. Hub renders all 6 `GenerationCard` tiles with non-zero term counts (proves JSON imports succeeded)
+8. Clicking a generation card navigates to `/apps/generations/<slug>` and renders the SlangApp
+9. Topbar "Dashboard" link returns to `/`
+10. AppNav contains all 6 generations as items
+
+### Group C — Per-generation page + tabs
+
+Run against one generation (gen-z by default; parameterize the spec so adding more is `for (const gen of GENERATIONS)`).
+
+11. `/apps/generations/gen-z` renders generation header (emoji, name, era, term count, tagline)
+12. Default tab is Dictionary
+13. Switching to Translator hides Dictionary content, shows direction toggle + textarea
+14. Switching to Quiz shows "Question 1 of 10" and 4 options
+15. Switching to Trending shows ranked grid (#1 .. #20)
+16. `/apps/generations/not-a-real-slug` → 404 (Next `notFound()`)
+
+### Group D — Dictionary (search + category filter)
+
+17. Search input filters term cards client-side (type a term known to exist in `gen-z.json`, list narrows to >=1 card containing that term)
+18. Search by alias matches (term whose `aliases` includes the query)
+19. Search with no matches renders the empty state ("No slang found for that search.")
+20. Category pills include "all" + every distinct category in the JSON
+21. Clicking a category pill filters to that category only; count line updates
+22. Clicking "all" restores the full list
+23. Term cards render: term, definition, example, vibe bar with score N/10, category badge
+
+### Group E — Translator
+
+24. Default direction is `English -> {Gen}`; toggle switches to `{Gen} -> English` and clears prior result
+25. Empty input + Translate button → result reads "Type something first!"
+26. Known phrase translation (e.g. on gen-z, input "this is good" -> result contains "it slaps", emphasized via `<strong>`)
+27. Unknown input on `to-gen` → fallback line "Couldn't find common words to translate. Try terms like: ..."
+28. Cmd/Ctrl+Enter in textarea triggers translate
+29. `from-gen` direction decodes a known slang term back into a definition snippet
+30. XSS guard: input `<script>alert(1)</script>` is escaped; no script executes (assert via `page.on("dialog")` never fires + result text contains literal "&lt;script&gt;" in the rendered HTML)
+
+### Group F — Quiz
+
+31. Quiz shows 10 questions (count progress dots)
+32. Selecting an option disables the other options and reveals "Next" button
+33. Selecting the correct definition marks the option green and increments score on Next
+34. Selecting a wrong definition marks picked option red and the correct one green
+35. After 10 questions, results screen shows score `X/10`, fluency percent, and a tier message ("Total Outsider" / "Needs Work" / "Getting There" / "Solid" / "Certified")
+36. "Try Again" button resets to question 1 with a fresh question set (different term order is acceptable; just assert current=1 of 10)
+
+### Group G — Trending
+
+37. Trending grid renders 20 tiles (or `terms.length` if fewer than 20)
+38. Tile #1 has the highest `vibeScore` for that generation (assert order matches a sort of the JSON, not a hard-coded term)
+39. Each tile shows rank `#N`, term, and category badge
+
+### Group H — Static params / SSG sanity
+
+40. `generateStaticParams` produces all 6 generation slugs — assert by hitting each `/apps/generations/<slug>` and confirming 200 + correct header. One spec, six iterations. Catches a regression if a JSON file is removed without updating the registry list.
+
+## 4. Spec organization
+
+```
+apps/web/tests/e2e/generations/
+  access.spec.ts            # A — auth + tier gate + UpgradePrompt
+  hub.spec.ts               # B — landing page navigation
+  gen-page.spec.ts          # C, H — per-gen routing + tab switching + 404 + SSG sweep
+  dictionary.spec.ts        # D — search + category filter
+  translator.spec.ts        # E — direction toggle + translation + XSS escape
+  quiz.spec.ts              # F — quiz state machine + results
+  trending.spec.ts          # G — trending wall ordering
+```
+
+Each file: `beforeAll` seeds permission (and Pro subscription if needed) for the test user; no `afterEach` cleanup needed (no per-user data writes). Uses the shared `loggedInPage` fixture.
+
+## 5. Selector strategy (do this before writing specs)
+
+Today the components rely on text + a few `aria-` attributes; to keep tests stable against copy/style churn, add `data-testid` hooks to the high-traffic interactions in `slang-app.tsx`, `slang-dictionary.tsx`, `slang-translator.tsx`, `slang-quiz.tsx`, `generation-card.tsx`:
+
+- `generation-hub`, `generation-card-${slug}`, `generation-chip-${slug}`
+- `slang-app`, `tab-${dictionary|translator|quiz|trending}`, `tab-content-${...}`
+- `dictionary-search`, `category-pill-${name}`, `dictionary-empty`, `term-card`, `term-card-title`, `term-card-vibe-score`
+- `translator-direction-${to-gen|from-gen}`, `translator-input`, `translator-submit`, `translator-result`
+- `quiz-progress-dot-${i}`, `quiz-question`, `quiz-option-${i}`, `quiz-next`, `quiz-result`, `quiz-score`, `quiz-restart`
+- `trending-tile`, `trending-rank-${n}`
+
+Small, surgical, and avoids querying by emoji/text.
+
+## 6. Running
+
+- `pnpm --filter web test:e2e` (existing script) → `playwright test`
+- Local: dev server is reused (`reuseExistingServer: !CI`)
+- CI: `next build && next start` already in `webServer.command` flow. Add `generations` to `APP_SELF_ENROLL_SLUGS` env in `playwright.config.ts` only if you decide to swap the explicit `seedPermission` call for self-enroll-on-first-visit. Default plan keeps the explicit seed.
+
+## 7. Out of scope
+
+- **Already covered by unit tests** in `apps/web/app/apps/generations/__tests__/`:
+  - `gen-page.test.tsx` — per-generation page server-component rendering
+  - `generation-card.test.tsx` — card markup
+  - `layout.test.tsx` — `requireAccess` + `enforceFeatureTier` + `UpgradePrompt`
+  - `slang-dictionary.test.tsx` — search/category filter logic
+  - `slang-quiz.test.tsx` — quiz state machine
+  E2E should cover the full UI→browser path (tab switching, real client-side filters, real DOM events) but should NOT re-assert pure component logic already locked down by Vitest.
+- **Slang-translator unit tests** do not exist today — the e2e Group E carries the regression burden until a unit test is added. Note this in the PR.
+- Visual regression (screenshot diff) — separate effort.
+- Cross-browser matrix — `playwright.config.ts` is chromium-only; out of scope here.
+- AI-assisted translator (the current translator is a static word map; if this gets replaced with an LLM call, revisit the rate-limit + mocking pattern from the Ideas plan's Group G).
+
+---
+
+## Execution order
+
+1. Add `data-testid` hooks (§5) — small PR, no behavior change
+2. Add `seedProSubscription` helper to `tests/e2e/helpers/db.ts` (only if not already present — this is the first `tier: "pro"` app under e2e)
+3. Write `access.spec.ts` first (highest value: it locks down the tier gate, which is the only thing unique to Pro apps)
+4. Layer in `hub.spec.ts` + `gen-page.spec.ts` (covers routing surface)
+5. Dictionary + Translator + Quiz + Trending in any order (independent client features)

--- a/docs/superpowers/plans/2026-04-30-hspt-practice-e2e-testing.md
+++ b/docs/superpowers/plans/2026-04-30-hspt-practice-e2e-testing.md
@@ -1,0 +1,77 @@
+# Plan: E2E tests for the HSPT Practice app
+
+> Seed for `alpha-plan`. Drafted 2026-04-30.
+
+Existing infra (Playwright at `apps/web/playwright.config.ts`, `loggedInPage` fixture in `tests/e2e/fixtures/auth.fixture.ts`, `seedPermission` in `tests/e2e/helpers/db.ts`) is reused. HSPT Practice is a **client-only quiz** — questions live in static `data/questions.json`, sessions persist to `localStorage` only. No Supabase tables, no server actions, no migrations. That dictates the scope below.
+
+---
+
+## 1. Setup (one-time, prereq)
+
+- **Env vars** (`.env.local` for local, GH secrets for CI):
+  - `E2E_TEST_USER_EMAIL`, `E2E_TEST_USER_PASSWORD`, `E2E_TEST_USER_ID` — already used by the auth fixture.
+  - `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` — needed for `seedPermission` only.
+- **No new fixtures**: reuse `loggedInPage` from `auth.fixture.ts`.
+- **Permissions**: registry entry requires `view` (not `edit`). In `beforeAll` call `seedPermission(userId, "hspt-practice", "view")`. Tear down with `deletePermission` in `afterAll`.
+
+## 2. Test data strategy
+
+**No `helpers/hspt-practice.ts` is needed.** The app has zero server-side persistence — every session is written via `localStorage.setItem("hspt_sessions", ...)` from `components/practice-app.tsx`. Reading the DB to assert state would assert nothing.
+
+When a future test needs deterministic session history (e.g. to drive the History view), use Playwright's `page.addInitScript` to pre-seed `localStorage.hspt_sessions` before navigation. That keeps the seam in-browser, where the data actually lives.
+
+Why no DB seeding helpers: server-action unit tests don't exist for this app either (see `__tests__/layout.test.tsx`, `components/__tests__/practice-app.test.tsx`, `lib/__tests__/sections.test.ts` — all client/unit). E2E adds nothing by re-touching Supabase.
+
+## 3. Use-case catalog (test inventory) — Group A only
+
+Per the rules, minimal-template apps stay tight. Group A (access & gating) is the highest-value smoke layer; further groups (quiz flow, results, history) are explicitly **deferred** — see §6.
+
+### Group A — Access & gating (smoke)
+
+1. Unauth user → `/apps/hspt-practice` redirects to login (Auth0 universal login URL).
+2. Auth user without `hspt-practice` permission → `/unauthorized` page (registry sets `auth: true`, `permission: "view"`, no self-enroll).
+3. Auth user with `hspt-practice:view` → page renders the layout header (`📝 HSPT Practice`) and the section menu heading "Choose a Section".
+4. All five section tiles render in the menu — verify Verbal, Quantitative, Reading, Mathematics, Language by `data-testid="section-tile-${id}"` (added in §4).
+5. Empty-state copy "No practice sessions yet — start your first one!" is visible when `localStorage.hspt_sessions` is unset.
+
+That's the floor. Tier is `free`, so no billing-gate test exists; `features: {}` means no feature-flag dialogs to check.
+
+## 4. Selector strategy (do this before writing specs)
+
+Today the menu/quiz views are identified only by emoji + text — brittle once copy or icons change. Add `data-testid` hooks in `components/practice-app.tsx` only where the access tests touch:
+
+- `section-tile-${id}` on each `SectionMenu` button (id = `verbal | quantitative | reading | mathematics | language`).
+- `app-header` on the `<header>` in `layout.tsx` so the access spec asserts the chrome rendered, not just the page body.
+- `recent-sessions-empty` on the empty-state Card in `SectionMenu`.
+
+Skip testids for Quiz/Results/Review/History components until those groups are in scope — adding hooks we don't exercise is dead weight.
+
+## 5. Spec organization
+
+```
+apps/web/tests/e2e/hspt-practice/
+  access.spec.ts           # Group A — the only file for this milestone
+```
+
+Single file. `beforeAll` seeds permission; no `afterEach` data cleanup needed (no DB rows). Use `page.context().clearCookies()` / fresh context for the unauth case via the existing `unauthPage` fixture.
+
+## 6. Out of scope (explicitly deferred)
+
+- **Quiz flow / timer / scoring**: requires faking `Date.now`, `setInterval`, and `Math.random` (the section uses `shuffle()`). Belongs in a Vitest unit suite against `PracticeApp`, not Playwright — already partially covered by `components/__tests__/practice-app.test.tsx`.
+- **Results / Review / History views**: depend on a completed session; once Quiz flow is wired (with a deterministic seed + frozen clock), these get a single `quiz-flow.spec.ts` in a follow-up.
+- **localStorage persistence assertions**: reachable via `page.evaluate(() => localStorage.getItem("hspt_sessions"))`, but only meaningful once the quiz flow test exists to produce the value.
+- **Recharts rendering in History**: visual/regression territory — separate effort.
+
+## 7. Running
+
+- `pnpm --filter web test:e2e` (script already exists or mirrors the Ideas plan).
+- Local: dev server reused (`reuseExistingServer: !CI`).
+- CI: `webServer.env.APP_SELF_ENROLL_SLUGS` does **not** include `hspt-practice` and shouldn't — the negative-permission test (A2) depends on self-enroll being closed for this slug. Rely on `seedPermission` for the positive cases.
+
+---
+
+## Execution order
+
+1. Add the three `data-testid` hooks (§4) — small PR, no behavior change.
+2. Write `access.spec.ts` (Group A, ~5 tests).
+3. Defer everything in §6 to a follow-up plan once the quiz flow has unit-level determinism.


### PR DESCRIPTION
## Summary

- Plan for Playwright E2E coverage of the HSPT Practice app (`/apps/hspt-practice`, slug `hspt-practice`, tier `free`, `permission: "view"`).
- Scope intentionally narrowed to **Group A (access & gating)** — the app is client-only with `localStorage` persistence and zero server actions, so the Ideas-style DB seeding helper is explicitly omitted (and the rationale is documented).
- Calls out the three minimal `data-testid` hooks needed in `components/practice-app.tsx` + `layout.tsx` and defers Quiz/Results/Review/History to a follow-up gated on a deterministic clock + RNG seed.

## Test plan

- [ ] Land this plan; review §6 (out-of-scope) before any Group B+ work begins.
- [ ] Follow-up PR: add the three `data-testid` hooks listed in §4 (no behavior change).
- [ ] Follow-up PR: `apps/web/tests/e2e/hspt-practice/access.spec.ts` exercising the five Group A cases.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code