### PR TITLE
fix: add missing migrations + daily-updates API route

### DIFF
--- a/apps/web/app/api/daily-updates/route.ts
+++ b/apps/web/app/api/daily-updates/route.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { createClient } from "@repo/db/server";
+import { requireAccess } from "@repo/auth/server";
+import type { DailyUpdate } from "@/app/apps/daily-updates/lib/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const querySchema = z.object({
+  offset: z.coerce.number().int().min(0).default(0),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+});
+
+export async function GET(req: Request): Promise<Response> {
+  await requireAccess("daily-updates", "view");
+
+  const url = new URL(req.url);
+  const parsed = querySchema.safeParse({
+    offset: url.searchParams.get("offset") ?? undefined,
+    limit: url.searchParams.get("limit") ?? undefined,
+  });
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Invalid offset/limit" },
+      { status: 400 },
+    );
+  }
+  const { offset, limit } = parsed.data;
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("daily_updates")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  return Response.json(((data ?? []) as unknown) as DailyUpdate[]);
+}

--- a/supabase/migrations/20260430_clients.down.sql
+++ b/supabase/migrations/20260430_clients.down.sql
@@ -1,0 +1,2 @@
+drop index if exists public.idx_clients_name;
+drop table if exists public.clients;

--- a/supabase/migrations/20260430_clients.sql
+++ b/supabase/migrations/20260430_clients.sql
@@ -1,0 +1,36 @@
+-- Reconstructive migration capturing the schema implicitly required by
+-- apps/web/app/apps/accounts/. The Accounts app is read-only; rows are
+-- seeded out of band (or via the e2e helpers proposed in
+-- docs/superpowers/plans/2026-04-30-accounts-e2e-testing.md).
+--
+-- JSON-as-text (not jsonb) is intentional: queries.ts:27-33 calls
+-- JSON.parse only when typeof === "string". Switching these blob
+-- columns to jsonb would bypass that loop and silently break shapes
+-- that are already shipped as encoded strings.
+create table if not exists public.clients (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  status text,
+  health text,
+  industry text,
+  urls text,
+  contacts text,
+  github text,
+  jira text,
+  netlify text,
+  contracts text,
+  "contentfulSpaces" text,
+  standup text,
+  highlights text,
+  challenges text,
+  "upcomingFocus" text,
+  "upcomingMeetings" text,
+  "createdAt" timestamptz not null default now(),
+  "updatedAt" timestamptz not null default now()
+);
+
+-- Default-deny: app reads via service-role client; anon should not see
+-- this table directly. Same pattern as public.ideas post-Auth0.
+alter table public.clients enable row level security;
+
+create index if not exists idx_clients_name on public.clients (name);

--- a/supabase/migrations/20260430_dad_jokes.down.sql
+++ b/supabase/migrations/20260430_dad_jokes.down.sql
@@ -1,0 +1,3 @@
+drop index if exists public.idx_dad_jokes_category;
+drop index if exists public.idx_dad_jokes_featured_date;
+drop table if exists public.dad_jokes;

--- a/supabase/migrations/20260430_dad_jokes.sql
+++ b/supabase/migrations/20260430_dad_jokes.sql
@@ -1,0 +1,27 @@
+-- Catalog of dad jokes shown by the Dad Joke of the Day app. Read by
+-- both server and browser; counter columns (rating, times_rated,
+-- times_shown) are incremented from the browser via @repo/db/client.
+--
+-- RLS is left disabled on purpose: the app's existing contract is that
+-- any authenticated user can bump the public counters, and Auth0 issues
+-- the browser an anon-keyed Supabase client (auth.role() returns 'anon'
+-- under the Auth0 setup, so a 'authenticated'-gated policy would reject
+-- legit writes). Default Supabase grants on public schema let anon
+-- INSERT/UPDATE here without a policy.
+create table if not exists public.dad_jokes (
+  id bigserial primary key,
+  setup text not null,
+  punchline text not null,
+  category text not null,
+  rating numeric(3, 2),
+  times_rated integer not null default 0,
+  times_shown integer not null default 0,
+  featured_date date,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_dad_jokes_featured_date
+  on public.dad_jokes (featured_date desc nulls last);
+create index if not exists idx_dad_jokes_category
+  on public.dad_jokes (category);

--- a/supabase/migrations/20260430_daily_updates.down.sql
+++ b/supabase/migrations/20260430_daily_updates.down.sql
@@ -1,0 +1,6 @@
+drop index if exists public.idx_daily_update_profiles_name;
+drop table if exists public.daily_update_profiles;
+drop index if exists public.idx_daily_updates_category;
+drop index if exists public.idx_daily_updates_source_app_created_at;
+drop index if exists public.idx_daily_updates_created_at;
+drop table if exists public.daily_updates;

--- a/supabase/migrations/20260430_daily_updates.sql
+++ b/supabase/migrations/20260430_daily_updates.sql
@@ -1,0 +1,47 @@
+-- Tables backing the Daily Updates feed app. Posts are authored by other
+-- apps in the suite (source_app) and consumed read-only by this feed.
+-- Both tables are global (no user_id); access flows through the server
+-- API route at apps/web/app/api/daily-updates/route.ts, which gates on
+-- the daily-updates:view permission.
+--
+-- id is text (not uuid) so e2e helpers can prefix-scope cleanup with
+-- `e2e-` ids per the merged plan §2.
+
+create table if not exists public.daily_updates (
+  id text primary key,
+  title text not null,
+  body text not null default '',
+  source_app text not null,
+  source_name text not null,
+  source_icon text not null,
+  category text,
+  priority text,
+  links jsonb not null default '[]'::jsonb,
+  reactions jsonb not null default '{}'::jsonb,
+  tags jsonb not null default '[]'::jsonb,
+  image_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz default now()
+);
+alter table public.daily_updates enable row level security;
+
+create index if not exists idx_daily_updates_created_at
+  on public.daily_updates (created_at desc);
+create index if not exists idx_daily_updates_source_app_created_at
+  on public.daily_updates (source_app, created_at desc);
+create index if not exists idx_daily_updates_category
+  on public.daily_updates (category);
+
+create table if not exists public.daily_update_profiles (
+  id text primary key,
+  name text not null,
+  icon text not null,
+  personality text,
+  post_count integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz default now()
+);
+alter table public.daily_update_profiles enable row level security;
+
+create index if not exists idx_daily_update_profiles_name
+  on public.daily_update_profiles (name);

--- a/supabase/migrations/20260430_dance_submissions.down.sql
+++ b/supabase/migrations/20260430_dance_submissions.down.sql
@@ -1,0 +1,2 @@
+drop index if exists public.idx_dance_submissions_status_created;
+drop table if exists public.dance_submissions;

--- a/supabase/migrations/20260430_dance_submissions.sql
+++ b/supabase/migrations/20260430_dance_submissions.sql
@@ -1,0 +1,21 @@
+-- Backs the Roblox Dances submission flow. id is text (the client emits
+-- `sub-${Date.now()}`). Submissions are anonymous (`submitted_by`
+-- defaults to 'anonymous'); RLS left disabled so the browser anon key
+-- can upsert without per-user policy machinery — matches the app's
+-- existing path at dance-app.tsx:498-513.
+create table if not exists public.dance_submissions (
+  id text primary key,
+  name text not null,
+  emoji text not null default '🎵',
+  description text not null,
+  difficulty text not null default 'intermediate'
+    check (difficulty in ('beginner', 'intermediate', 'advanced', 'expert')),
+  tags jsonb not null default '[]'::jsonb,
+  submitted_by text not null default 'anonymous',
+  status text not null default 'pending'
+    check (status in ('pending', 'approved')),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_dance_submissions_status_created
+  on public.dance_submissions (status, created_at desc);

--- a/supabase/migrations/20260430_days.down.sql
+++ b/supabase/migrations/20260430_days.down.sql
@@ -1,0 +1,4 @@
+drop trigger if exists trg_days_updated_at on public.days;
+drop function if exists public.set_days_updated_at();
+drop index if exists public.idx_days_date_desc;
+drop table if exists public.days;

--- a/supabase/migrations/20260430_days.sql
+++ b/supabase/migrations/20260430_days.sql
@@ -1,0 +1,34 @@
+-- Reconstructive migration for the Standup app. Columns match the
+-- StandupDay TypeScript type so .select("*") -> StandupDay[] needs no
+-- adapter. Rows come from an external aggregation pipeline; the app is
+-- read-only.
+--
+-- id is text (not uuid) so e2e helpers can prefix-scope cleanup
+-- (`e2e-standup-${Date.now()}-...`) — the table has no user_id, so
+-- per-row deletion has to key on id, not user.
+create table if not exists public.days (
+  id text primary key,
+  date date not null,
+  "dayOfWeek" text not null,
+  activities jsonb not null default '[]'::jsonb,
+  "createdAt" timestamptz not null default now(),
+  "updatedAt" timestamptz not null default now()
+);
+
+alter table public.days enable row level security;
+
+create or replace function public.set_days_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new."updatedAt" = now();
+  return new;
+end;
+$$;
+
+create trigger trg_days_updated_at
+  before update on public.days
+  for each row execute function public.set_days_updated_at();
+
+create index if not exists idx_days_date_desc on public.days (date desc);

--- a/supabase/migrations/20260430_sites.down.sql
+++ b/supabase/migrations/20260430_sites.down.sql
@@ -1,0 +1,5 @@
+drop trigger if exists trg_sites_updated_at on public.sites;
+drop function if exists public.set_sites_updated_at();
+drop index if exists public.idx_sites_status;
+drop index if exists public.idx_sites_name;
+drop table if exists public.sites;

--- a/supabase/migrations/20260430_sites.sql
+++ b/supabase/migrations/20260430_sites.sql
@@ -1,0 +1,38 @@
+-- Reconstructive migration for the Uptime dashboard. Columns match the
+-- Site TypeScript type so apps/web/app/apps/uptime/page.tsx can cast
+-- .select("*") directly with no adapter (mirrors the public.ideas
+-- quoted-camelCase convention). Rows arrive from the external
+-- status-pulse repo; no in-app writes.
+create table if not exists public.sites (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  url text not null,
+  description text,
+  status text not null default 'up'
+    check (status in ('up', 'down', 'degraded')),
+  "responseTimeMs" integer,
+  "uptimePercent" numeric,
+  "lastChecked" timestamptz,
+  history jsonb not null default '[]'::jsonb,
+  "createdAt" timestamptz not null default now(),
+  "updatedAt" timestamptz not null default now()
+);
+
+alter table public.sites enable row level security;
+
+create or replace function public.set_sites_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new."updatedAt" = now();
+  return new;
+end;
+$$;
+
+create trigger trg_sites_updated_at
+  before update on public.sites
+  for each row execute function public.set_sites_updated_at();
+
+create index if not exists idx_sites_name on public.sites (name);
+create index if not exists idx_sites_status on public.sites (status);

--- a/supabase/migrations/20260430_sprint_planning_archives.down.sql
+++ b/supabase/migrations/20260430_sprint_planning_archives.down.sql
@@ -1,0 +1,6 @@
+drop index if exists public.idx_weekly_summaries_start_date;
+drop table if exists public.weekly_summaries;
+drop index if exists public.idx_daily_overviews_date;
+drop table if exists public.daily_overviews;
+drop index if exists public.idx_daily_digests_date;
+drop table if exists public.daily_digests;

--- a/supabase/migrations/20260430_sprint_planning_archives.sql
+++ b/supabase/migrations/20260430_sprint_planning_archives.sql
@@ -1,0 +1,49 @@
+-- Reconstructive migrations for the read-only Sprint Planning Archives
+-- tab: daily_digests, daily_overviews, weekly_summaries. All three are
+-- populated by an external ingestion pipeline; no in-app writes.
+--
+-- Snake_case throughout matches what the app's queries.ts/types.ts read
+-- directly. Lists (highlights/blockers/action_items/themes/items) are
+-- jsonb so the UI's defensive `typeof item === "string" ? item :
+-- JSON.stringify(item)` path keeps working if upstream emits objects.
+
+create table if not exists public.daily_digests (
+  id uuid primary key default gen_random_uuid(),
+  date date not null,
+  service text,
+  summary text,
+  item_count integer,
+  items jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now()
+);
+alter table public.daily_digests enable row level security;
+create index if not exists idx_daily_digests_date
+  on public.daily_digests (date desc);
+
+create table if not exists public.daily_overviews (
+  id uuid primary key default gen_random_uuid(),
+  date date not null,
+  summary text,
+  highlights jsonb not null default '[]'::jsonb,
+  blockers jsonb not null default '[]'::jsonb,
+  action_items jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now()
+);
+alter table public.daily_overviews enable row level security;
+create index if not exists idx_daily_overviews_date
+  on public.daily_overviews (date desc);
+
+create table if not exists public.weekly_summaries (
+  id uuid primary key default gen_random_uuid(),
+  start_date date not null,
+  end_date date,
+  summary text,
+  themes jsonb not null default '[]'::jsonb,
+  highlights jsonb not null default '[]'::jsonb,
+  blockers jsonb not null default '[]'::jsonb,
+  action_items jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now()
+);
+alter table public.weekly_summaries enable row level security;
+create index if not exists idx_weekly_summaries_start_date
+  on public.weekly_summaries (start_date desc);

--- a/supabase/migrations/20260430_summaries_sources.down.sql
+++ b/supabase/migrations/20260430_summaries_sources.down.sql
@@ -1,0 +1,7 @@
+drop index if exists public.idx_summaries_jira_created_at;
+drop table if exists public.summaries_jira;
+drop index if exists public.idx_summaries_slack_channel_id;
+drop index if exists public.idx_summaries_slack_created_at;
+drop table if exists public.summaries_slack;
+drop index if exists public.idx_summaries_zoom_created_at;
+drop table if exists public.summaries_zoom;

--- a/supabase/migrations/20260430_summaries_sources.sql
+++ b/supabase/migrations/20260430_summaries_sources.sql
@@ -1,0 +1,55 @@
+-- Reconstructive migrations for the Summaries app's three external-source
+-- tables: summaries_zoom, summaries_slack, summaries_jira. All three are
+-- read-only over rows ingested by external Zoom/Slack/Jira webhooks.
+--
+-- tone/priority/status are intentionally plain text (no CHECK
+-- constraint): the upstream pipeline may emit values the in-app pill
+-- maps fall back on, and a check would reject legitimate ingested rows.
+-- jsonb everywhere for list columns matches the parseJsonField path,
+-- which tolerates either real arrays or JSON-encoded strings.
+
+create table if not exists public.summaries_zoom (
+  id uuid primary key default gen_random_uuid(),
+  meeting_id text not null,
+  meeting_topic text not null,
+  short_summary text,
+  long_summary text,
+  action_items jsonb not null default '[]'::jsonb,
+  key_decisions jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+alter table public.summaries_zoom enable row level security;
+create index if not exists idx_summaries_zoom_created_at
+  on public.summaries_zoom (created_at desc);
+
+create table if not exists public.summaries_slack (
+  id uuid primary key default gen_random_uuid(),
+  thread_ts text not null,
+  channel_id text not null,
+  participants jsonb not null default '[]'::jsonb,
+  short_summary text,
+  long_summary text,
+  tone text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+alter table public.summaries_slack enable row level security;
+create index if not exists idx_summaries_slack_created_at
+  on public.summaries_slack (created_at desc);
+create index if not exists idx_summaries_slack_channel_id
+  on public.summaries_slack (channel_id);
+
+create table if not exists public.summaries_jira (
+  id uuid primary key default gen_random_uuid(),
+  ticket_key text not null,
+  short_summary text,
+  long_summary text,
+  priority text,
+  status text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+alter table public.summaries_jira enable row level security;
+create index if not exists idx_summaries_jira_created_at
+  on public.summaries_jira (created_at desc);

--- a/supabase/migrations/20260430_travel_properties.down.sql
+++ b/supabase/migrations/20260430_travel_properties.down.sql
@@ -1,0 +1,8 @@
+drop index if exists public.idx_travel_properties_name;
+drop index if exists public.idx_travel_properties_type;
+drop index if exists public.idx_travel_properties_region;
+drop index if exists public.idx_travel_properties_category;
+drop trigger if exists trg_travel_properties_updated_at on public.travel_properties;
+drop function if exists public.set_travel_properties_updated_at();
+drop policy if exists "travel_properties_public_read" on public.travel_properties;
+drop table if exists public.travel_properties;

--- a/supabase/migrations/20260430_travel_properties.sql
+++ b/supabase/migrations/20260430_travel_properties.sql
@@ -1,0 +1,56 @@
+-- Read-only catalog backing the public Travel Collection app
+-- (auth=false). RLS enabled with a permissive public-read policy so
+-- anonymous SSR (and any future browser direct-read) can render the
+-- gallery without an Auth0 session. No in-app writes — rows arrive via
+-- seed scripts / external admin tooling.
+--
+-- "researched/pending" is a single boolean (`researched`); "pending" is
+-- derived as `!researched` in the UI. Don't add a status enum.
+create table if not exists public.travel_properties (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  location text not null default '',
+  region text not null default '',
+  category text not null default '',
+  type text not null default '',
+  description text,
+  website text,
+  pricing text,
+  photos jsonb,
+  amenities jsonb,
+  highlights jsonb,
+  tags jsonb,
+  rating numeric check (rating is null or rating between 0 and 5),
+  researched boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.travel_properties enable row level security;
+
+create policy "travel_properties_public_read"
+  on public.travel_properties for select
+  using (true);
+
+create or replace function public.set_travel_properties_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger trg_travel_properties_updated_at
+  before update on public.travel_properties
+  for each row execute function public.set_travel_properties_updated_at();
+
+create index if not exists idx_travel_properties_category
+  on public.travel_properties (category);
+create index if not exists idx_travel_properties_region
+  on public.travel_properties (region);
+create index if not exists idx_travel_properties_type
+  on public.travel_properties (type);
+create index if not exists idx_travel_properties_name
+  on public.travel_properties (name);

--- a/supabase/migrations/20260430_wine_pours.down.sql
+++ b/supabase/migrations/20260430_wine_pours.down.sql
@@ -1,0 +1,4 @@
+drop index if exists public.idx_pour_wall_created_at;
+drop table if exists public.pour_wall;
+drop index if exists public.idx_wine_pours_created_at;
+drop table if exists public.wine_pours;

--- a/supabase/migrations/20260430_wine_pours.sql
+++ b/supabase/migrations/20260430_wine_pours.sql
@@ -1,0 +1,34 @@
+-- Tables backing the Proper Wine Pour app. Both are anonymous community
+-- tables — id columns are TEXT (the client generates `pour-${Date.now()}`
+-- and `wall-${Date.now()}` literals; uuid would reject those payloads).
+--
+-- RLS left disabled so the browser anon key can insert/upvote without
+-- per-user policy machinery. Matches the app's existing read/write
+-- contract: writes go through the browser supabase client (cast to any
+-- because generated types don't include these tables today).
+
+create table if not exists public.wine_pours (
+  id text primary key,
+  restaurant_name text not null default '',
+  wine_name text not null default '',
+  pour_rating text not null default 'standard'
+    check (pour_rating in ('generous', 'standard', 'stingy', 'criminal')),
+  price_paid numeric,
+  notes text,
+  user_name text not null default 'Anonymous',
+  created_at timestamptz not null default now()
+);
+create index if not exists idx_wine_pours_created_at
+  on public.wine_pours (created_at desc);
+
+create table if not exists public.pour_wall (
+  id text primary key,
+  user_name text not null default 'Anonymous',
+  pour_type text not null default 'glory'
+    check (pour_type in ('glory', 'shame')),
+  content text not null default '',
+  upvotes integer not null default 0,
+  created_at timestamptz not null default now()
+);
+create index if not exists idx_pour_wall_created_at
+  on public.pour_wall (created_at desc);


### PR DESCRIPTION
## Summary

Adds the 15 Supabase tables and 1 API route flagged across the merged E2E test plans (PRs #382–#408) as referenced-but-not-committed.

**Tables (10 migration files):**
| File | Tables | App |
|---|---|---|
| `20260430_clients.sql` | `public.clients` | Accounts |
| `20260430_sites.sql` | `public.sites` | Uptime |
| `20260430_days.sql` | `public.days` | Standup |
| `20260430_sprint_planning_archives.sql` | `daily_digests`, `daily_overviews`, `weekly_summaries` | Sprint Planning |
| `20260430_summaries_sources.sql` | `summaries_zoom`, `summaries_slack`, `summaries_jira` | Summaries |
| `20260430_daily_updates.sql` | `daily_updates`, `daily_update_profiles` | Daily Updates |
| `20260430_dad_jokes.sql` | `public.dad_jokes` | Dad Joke of the Day |
| `20260430_wine_pours.sql` | `wine_pours`, `pour_wall` | Proper Wine Pour |
| `20260430_travel_properties.sql` | `public.travel_properties` | Travel Collection |
| `20260430_dance_submissions.sql` | `public.dance_submissions` | Roblox Dances |

**API route:**
- `apps/web/app/api/daily-updates/route.ts` — `GET` handler powering `feed-app.tsx:284` pagination. Validates `offset`/`limit` with Zod, gates on `requireAccess("daily-updates", "view")`, queries via service-role client, returns `DailyUpdate[]`.

## Schema decisions

- Each schema was derived from the app's actual queries (cited file:line in research) and the merged plan §2/§3.
- **Idempotent**: every table uses `CREATE TABLE IF NOT EXISTS` so the migration no-ops cleanly in environments where the table was already created via the Supabase SQL editor.
- **Column casing matches the code**: `clients`, `sites`, `days` use quoted camelCase (matching the public.ideas pattern so `.select("*")` casts directly to the TS types). The rest use snake_case.
- **No auth.uid()-based RLS**: matches the post-Auth0 baseline established by `20260429_user_id_text.sql`. Server-only-read tables get `enable row level security` with no policies (default-deny; service-role bypasses). Browser-writable community tables (`dad_jokes`, `wine_pours`, `pour_wall`, `dance_submissions`) leave RLS disabled so anon-key writes match the existing app contract.
- **`id text` (not uuid)** where the client generates string ids (`days`, `daily_updates`, `daily_update_profiles`, `wine_pours`, `pour_wall`, `dance_submissions`) — uuid would reject the existing payloads.
- **Each up file paired with `.down.sql`** per the `scripts/check-migration-pairs.ts` lint rule. Verified passing.

## Validation

- `node --experimental-strip-types scripts/check-migration-pairs.ts` → `Migration pair check OK: 21 migration(s), all paired.`
- `pnpm --filter web typecheck` → no new errors. The two pre-existing test errors in `apps/web/app/apps/uptime/__tests__/page.test.tsx` and `apps/web/app/apps/sentiment/__tests__/page.test.tsx` exist on `origin/main` and are unrelated.

## Test plan

- [ ] Verify schemas against live Supabase — for any table that already exists with different columns, the `IF NOT EXISTS` will silently skip; confirm column shapes match before applying to envs that don't already have the table.
- [ ] Confirm the `dad_jokes`/`wine_pours`/`pour_wall`/`dance_submissions` permissive-RLS posture (RLS disabled, anon-key writes) matches the security stance you want.
- [ ] Hit `GET /api/daily-updates?offset=0&limit=20` once the migration is applied and verify pagination works in the feed.
- [ ] Spot-check the column-case decisions on `sites` (quoted camelCase) — the merged Uptime plan §2 listed snake_case names; the migration matches the app code rather than the plan, since the page does `.select("*")` and casts to a camelCase TS type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)