### PR TITLE
fix: restore CLAUDE.md content + lib-listing markers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,126 @@
 <!-- managed by alpha-loop -->
-Rewrote `CLAUDE.md` with actual instructions (the prior file was meta-commentary describing a previous rewrite). 92 lines, 5 required sections, marker preserved on line 1.
 
-Key corrections vs. the old summary:
-- **Packages** — now lists all 10 (`auth`, `billing`, `config`, `db`, `email`, `logger`, `storage`, `test-utils`, `theme`, `ui`); the old file said 7 and missed `email`, `logger`, `storage`.
-- **lib-listing block** — added the `<!-- lib-listing:start -->`/`<!-- lib-listing:end -->` markers required by `scripts/check-claude-md-lib-sync.ts`. Without them `pnpm lint` fails. Verified in sync.
-- **Tech stack** — added Sentry 10, OpenTelemetry, Resend (email), Upstash Redis, Stripe v17, exact pnpm version.
-- **Non-negotiables** — kept the registry/proxy/`requireAppLayoutAccess`/`getAuth0ClientForHost`/`turbo.json globalEnv`/append-only-migrations/billing rules, and added the explicit migration-pair-lint and lib-listing-lint rules surfaced from the codebase.
+# lr-apps
+
+## Overview
+
+Monorepo hosting 27+ micro-apps behind a single Next.js 16 host (`apps/web/`)
+with shared workspace packages under `packages/`. Apps are routed by
+subdomain via the registry in `apps/web/lib/app-registry.ts` and gated by
+Auth0 + Supabase-backed permissions. Subscription tiers (`free`/`pro`/
+`enterprise`) and per-feature overrides are enforced through `@repo/billing`
++ Stripe. Local dev uses Supabase, Playwright for E2E, and `punchlist-qa`
+alongside `next dev`.
+
+## Tech Stack
+
+- **Runtime/build:** Node 22+, pnpm 9.15.4, Turborepo 2.x, TypeScript 5
+- **Framework:** Next.js 16 (App Router, Turbopack), React 19, Tailwind 4
+- **Auth:** Auth0 (`@auth0/nextjs-auth0` v4) — multi-host via `getAuth0ClientForHost`
+- **Data:** Supabase (`@supabase/ssr` + `@supabase/supabase-js`); migrations in `supabase/migrations/`
+- **Cache:** Upstash Redis (`@upstash/redis`) keyed by `CACHE_VERSION`
+- **Billing:** Stripe v17 (`@repo/billing`), webhook handler at `app/api/webhooks/`
+- **AI:** AI SDK v6 + `@ai-sdk/anthropic` (Anthropic via `ANTHROPIC_API_KEY`)
+- **Email:** Resend v6 (`@repo/email`)
+- **Observability:** Sentry 10 (`@sentry/nextjs`), OpenTelemetry SDK + OTLP HTTP exporter
+- **Testing:** Vitest 4, Playwright 1, `@testing-library/jest-dom`, jsdom
+
+## Directory Structure
+
+```
+apps/web/                  Single Next.js host serving all apps
+  app/(auth)/              Auth hub (login, dashboard, forms) — subdomain "auth"
+  app/apps/<slug>/         Per-app route groups (registry-driven)
+  app/api/                 checkout, cron, health, vitals, webhooks
+  components/              Cross-app shared components (cards, headers, logos)
+  lib/                     Web-host helpers (see lib-listing below)
+  proxy.ts                 Routing middleware: subdomain → route, CSRF, CSP, rate-limit
+  instrumentation*.ts      OpenTelemetry + Sentry init
+packages/
+  analytics/  @repo/analytics — server/client/backend capture wrappers
+  auth/       @repo/auth — Auth0 factory, requireAccess, self-enroll
+  billing/    @repo/billing — Stripe client, customers, subscriptions, feature flags
+  config/     @repo/config — shared tsconfig/eslint
+  db/         @repo/db — Supabase server/client/middleware, cache, audit
+  email/      @repo/email — Resend wrapper + templates
+  logger/     @repo/logger — structured logging
+  storage/    @repo/storage — file/blob helpers
+  test-utils/ @repo/test-utils — shared vitest fixtures
+  theme/      @repo/theme — design tokens (enforced by audit:tokens)
+  ui/         @repo/ui — shared React UI components
+supabase/migrations/       Append-only SQL; every X.sql needs X.down.sql
+scripts/                   create-app, db-rollback, db-seed, lint checkers
+docs/                      Operational/architecture docs
+```
+
+`apps/web/lib/` contents (kept in sync with `scripts/check-claude-md-lib-sync.ts`):
+
+<!-- lib-listing:start -->
+- `app-card-media.ts`
+- `app-host.ts`
+- `app-registry.ts`
+- `auth-login-redirect.ts`
+- `cron-auth.ts`
+- `csp.ts`
+- `csrf.ts`
+- `enforce-feature-tier.ts`
+- `env.ts`
+- `health-checks.ts`
+- `otel-sdk.ts`
+- `otel.ts`
+- `platform-urls.ts`
+- `proxy-utils.ts`
+- `rate-limit.ts`
+- `require-app-layout-access.ts`
+- `tier-config.ts`
+- `validate-request.ts`
+<!-- lib-listing:end -->
+
+## Code Style
+
+- TypeScript strict; ESM (`"type": "module"`); no default exports for utilities.
+- Prefer named workspace subpath imports (e.g. `@repo/auth/server`,
+  `@repo/db/cache`). Do not deep-import package internals.
+- Server-only modules must not be imported from client components — respect
+  `@repo/db/server` vs `@repo/db/client` and `@repo/auth/server` vs `/client`.
+- Tailwind-first styling; design tokens come from `@repo/theme`. Hardcoded
+  colors fail `pnpm audit:tokens`.
+- Comments only for non-obvious *why* (security invariants, ordering quirks).
+  Don't restate code. Don't reference task/PR numbers in source.
+- Schemas validated with Zod v4 at trust boundaries (route handlers,
+  webhooks, server actions).
+
+## Non-Negotiables
+
+1. **Registry is the source of truth** for routing, auth, tier, and public
+   routes. Add new apps via `pnpm create-app <slug>`; never hand-edit a
+   route group without an `app-registry.ts` entry.
+2. **`requireAppLayoutAccess(slug, pathname)`** must wrap every gated app
+   layout. Public routes go through `publicRoutes` in the registry — do
+   not bypass the helper.
+3. **Auth0 host resolution** must use `getAuth0ClientForHost(...)` from
+   `@repo/auth/auth0-factory`. Never instantiate `auth0.Auth0Client`
+   directly — multi-domain (`*.apps.lastrev.com`, `*.lastrev.com`,
+   `*.apps.lastrev.localhost`) depends on the factory.
+4. **`proxy.ts`** owns subdomain rewriting, CSRF, CSP nonce, and rate
+   limiting. Side-effect import `./lib/app-registry` must remain so the
+   self-enroll tier resolver is registered before requests are served.
+5. **Migrations are append-only.** Every `supabase/migrations/<name>.sql`
+   needs a matching `<name>.down.sql`. Enforced by
+   `scripts/check-migration-pairs.ts` in `pnpm lint`.
+6. **`turbo.json` `globalEnv`** must list every env var the app reads.
+   Adding a var without registering it here means Turbo will not pass it
+   through and builds will silently use stale values. Mirror the same var
+   in `.env.example`.
+7. **`apps/web/lib/` listing** between the `lib-listing:start`/`:end`
+   markers above must match the filesystem. Enforced by
+   `scripts/check-claude-md-lib-sync.ts` in `pnpm lint`.
+8. **Billing/feature gates** go through `@repo/billing/has-feature-access`
+   and `enforce-feature-tier.ts`. Never inline tier checks against the
+   subscription row — feature overrides on the registry entry must win.
+9. **Stripe webhooks** are verified with `STRIPE_WEBHOOK_SECRET` and
+   handled idempotently via the `webhook_events` table. Never trust the
+   request body without signature verification.
+10. **CSP nonce** generated in `proxy.ts` flows through `applyCspHeader`
+    and must be threaded into any inline script tag (`<Script nonce>`).
+    Don't disable CSP — set `CSP_REPORT_ONLY=1` to debug.


### PR DESCRIPTION
## Summary

`CLAUDE.md` on `main` was 9 lines of meta-commentary describing a planned rewrite that never actually landed in the file. As a result, every PR's `Lint` job has been failing with:

```
Files present in apps/web/lib/ but missing from CLAUDE.md:
  - app-card-media.ts
  - app-host.ts
  ... (18 entries)
Update the listing between <!-- lib-listing:start --> and <!-- lib-listing:end --> in CLAUDE.md.
```

This PR applies the rewrite that was supposed to ship:

- Adds the five required sections (Overview, Tech Stack, Directory Structure, Code Style, Non-Negotiables).
- Adds the `<!-- lib-listing:start --> / <!-- lib-listing:end -->` markers wrapping bullets that match every `.ts` file currently in `apps/web/lib/` (18 entries).

## Validation

- `node --experimental-strip-types scripts/check-claude-md-lib-sync.ts` → `CLAUDE.md lib listing is in sync with apps/web/lib/.`
- `node --experimental-strip-types scripts/check-migration-pairs.ts` → `Migration pair check OK: 21 migration(s), all paired.`

## Test plan

- [ ] Confirm the restored content matches your intended CLAUDE.md (Tech Stack versions, Non-Negotiables wording, etc.). If anything is wrong, easier to amend now than after merge.
- [ ] Verify the Lint job goes green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)