### PR TITLE
fix(web): unblock unit + e2e test suites

### DIFF
--- a/apps/web/app/apps/sprint-planning/__tests__/sprint-app.test.tsx
+++ b/apps/web/app/apps/sprint-planning/__tests__/sprint-app.test.tsx
@@ -1,10 +1,19 @@
 // @vitest-environment jsdom
 import React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 import { act } from "react";
 import { renderWithProviders, screen, fireEvent, waitFor } from "@repo/test-utils";
 import type { SprintData, ArchiveRecord } from "../lib/types";
 import { SprintApp } from "../components/sprint-app";
+
+// Freeze the clock so date-window filters in the Archives view (Last 7/30 days)
+// are evaluated against a known "today" — otherwise the hardcoded archive dates
+// drift out of range as real-world time advances.
+vi.useFakeTimers({ shouldAdvanceTime: true });
+vi.setSystemTime(new Date("2026-04-09T12:00:00Z"));
+afterAll(() => {
+  vi.useRealTimers();
+});
 
 // ── Mock data ──────────────────────────────────────────────────────────────
 

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const AUTH_STATE_PATH = path.join(
   __dirname,

--- a/apps/web/tests/e2e/a11y-audit.spec.ts
+++ b/apps/web/tests/e2e/a11y-audit.spec.ts
@@ -15,7 +15,10 @@ import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { getAllApps, type AppConfig } from "../../lib/app-registry";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
 const STRICT = process.env.STRICT_A11Y === "1";

--- a/apps/web/tests/e2e/alpha-wins/access.spec.ts
+++ b/apps/web/tests/e2e/alpha-wins/access.spec.ts
@@ -11,7 +11,7 @@
 
 import { test, expect } from "../fixtures/auth.fixture";
 import { deletePermission, seedPermission } from "../helpers/db";
-import winsData from "../../../app/apps/alpha-wins/data/wins.json";
+import winsData from "../../../app/apps/alpha-wins/data/wins.json" with { type: "json" };
 
 const APP_SLUG = "alpha-wins";
 const APP_ROUTE = "/apps/alpha-wins";

--- a/apps/web/tests/e2e/fixtures/auth.fixture.ts
+++ b/apps/web/tests/e2e/fixtures/auth.fixture.ts
@@ -1,6 +1,9 @@
 import { test as base, type BrowserContext, type Page } from "@playwright/test";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const AUTH_STATE_PATH = path.join(__dirname, "../.auth/user.json");
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";

--- a/apps/web/tests/e2e/global-setup.ts
+++ b/apps/web/tests/e2e/global-setup.ts
@@ -1,6 +1,9 @@
 import { chromium } from "@playwright/test";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const AUTH_STATE_PATH = path.join(__dirname, ".auth/user.json");
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";

--- a/apps/web/tests/e2e/global-teardown.ts
+++ b/apps/web/tests/e2e/global-teardown.ts
@@ -1,5 +1,8 @@
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const AUTH_STATE_PATH = path.join(__dirname, ".auth/user.json");
 

--- a/apps/web/tests/e2e/mobile-audit.spec.ts
+++ b/apps/web/tests/e2e/mobile-audit.spec.ts
@@ -18,7 +18,10 @@
 
 import { test, expect, type Page } from "@playwright/test";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { getAllApps, type AppConfig } from "../../lib/app-registry";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
 


### PR DESCRIPTION
## Summary
- **Sprint-app archive tests** drifted: dates were seeded relative to a hardcoded `TODAY = 2026-04-09`, but the component's "Last 7/30 days" filter uses real `new Date()`. As real-world time passes, archives slid outside the default window and `screen.getByText("Weekly")` started failing. Freeze the clock with `vi.useFakeTimers()` + `vi.setSystemTime(...)`.
- **Playwright config + fixtures + specs** used `__dirname`, which is undefined in ESM. The package declares `"type": "module"`, so `playwright test` crashed at config load with `ReferenceError: __dirname is not defined in ES module scope` and listed 0 tests. Replaced with `path.dirname(fileURLToPath(import.meta.url))` in 6 files.
- **Alpha-wins access spec** imports a JSON file; under ESM it needs the `with { type: "json" }` import attribute.

## Test plan
- [x] `pnpm test` → 1079/1079 unit tests pass across 145 files (12/12 turbo tasks succeed)
- [x] `pnpm --filter @repo/web test:e2e` → 119 passed, 26 skipped (credential-gated), 0 failed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)